### PR TITLE
Fix error opening a usage link

### DIFF
--- a/autoload/kite/hover.vim
+++ b/autoload/kite/hover.vim
@@ -445,12 +445,12 @@ function! s:show_code(file, line, ...)
   else
     execute 'noautocmd keepjumps keepalt '.bufwinnr(t:source_buffer).'wincmd w'
     if a:0
-      if a:file !=# expand('%:p')
+      if a:file !=? expand('%:p')
         execute 'hide edit' a:file
       endif
       execute (a:1 + 1).'go'
     else
-      if a:file !=# expand('%:p')
+      if a:file !=? expand('%:p')
         execute 'hide edit +'.a:line a:file
       else
         execute a:line


### PR DESCRIPTION
There are two changes in this commit:

- Case-insensitive filename comparison (filenames from kited are all lowercase whereas Vim returns the actual filenames).
- Temporarily set the `hidden` option when loading a file to cope with rare situation when user doesn't already have `hidden` set.

See #53.