### PR TITLE
Renaming strings to match the new glossary.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 ### Features
 
-- [Integrates with Kite Sidebar (macOS)](#kite-sidebar)
+- [Integrates with Kite Copilot (macOS)](#kite-copilot)
 - [Completions](#completions)
 - [Documentation](#documentation)
 - [Statusline](#statusline)
@@ -44,9 +44,9 @@ $ git clone https://github.com/kiteco/vim-plugin.git ~/.config/nvim/pack/kite/st
 Restart Neovim.
 
 
-### Kite Sidebar
+### Kite Copilot
 
-As you edit your code in Vim/Neovim, the Kite Sidebar will show completions, popular patterns, code examples, and documentation for the code under the cursor.
+As you edit your code in Vim/Neovim, the Kite Copilot will show completions, examples, and docs for the code under the cursor.
 
 
 ### Completions

--- a/autoload/kite/hover.vim
+++ b/autoload/kite/hover.vim
@@ -80,7 +80,7 @@ function! kite#hover#handler(response)
       call add(patterns, name.'('.join(arguments, ', ').')')
     endfor
     if !empty(patterns)
-      call s:section('POPULAR PATTERNS')
+      call s:section('HOW OTHERS USED THIS')
       call s:content(patterns)
     endif
 
@@ -135,7 +135,7 @@ function! kite#hover#handler(response)
     " a.i, a.ii
     let members = map(copy(symbol.value[0].details.module.members), {_,v -> [v.name, v.value[0].kind]})
     if !empty(members)
-      call s:section('TOP MEMBERS')
+      call s:section('POPULAR MEMBERS')
       let members_with_types = kite#utils#columnise(members, '    ')
       let i = 0
       for line in members_with_types
@@ -241,7 +241,7 @@ function! kite#hover#handler(response)
     " i. Name, ii. Id
     let members = map(copy(symbol.value[0].details.type.members), {_,v -> [v.name, !empty(v.value) ? v.value[0].kind : '']})
     if !empty(members)
-      call s:section('TOP ATTRIBUTES')
+      call s:section('POPULAR MEMBERS')
       let members_with_types = kite#utils#columnise(members, '    ')
       let i = 0
       for line in members_with_types
@@ -273,7 +273,7 @@ function! kite#hover#handler(response)
 
 
 
-  call s:section('DOCUMENTATION')
+  call s:section('DESCRIPTION')
   " Handle embedded line breaks.
   call s:content(split(report.description_text, "\n"))
 
@@ -304,7 +304,7 @@ function! kite#hover#handler(response)
 
 
   if !empty(report.examples)
-    call s:section('EXAMPLES')
+    call s:section('HOW TO')
     for example in report.examples
       call s:content('-> '.example.title)
       let s:clickables[line('$')] = {
@@ -475,6 +475,3 @@ endfunction
 function! s:content(text)
   call append(line('$'), a:text)
 endfunction
-
-
-

--- a/autoload/kite/signature.vim
+++ b/autoload/kite/signature.vim
@@ -94,7 +94,7 @@ function! kite#signature#handler(response) abort
     let signatures = call.signatures
     if len(signatures) > 0
       call add(completions, spacer)
-      call add(completions, s:heading('Popular Patterns'))
+      call add(completions, s:heading('How Others Used This'))
     endif
 
     for signature in signatures
@@ -135,4 +135,3 @@ endfunction
 function s:heading(text)
   return {'abbr': a:text.':', 'word': '', 'empty': 1, 'dup': 1}
 endfunction
-

--- a/autoload/kite/status.vim
+++ b/autoload/kite/status.vim
@@ -44,7 +44,7 @@ function! kite#status#handler(buffer, response)
 
   if !exists('b:kite_whitelist_checked')
     if status ==? 'not whitelisted'
-      call kite#utils#info("Kite is not enabled for this file. Please whitelist it in Kite's settings to enable Kite.")
+      call kite#utils#info("Kite is not enabled for this file. Please whitelist it in Kite settings to enable Kite.")
     endif
     let b:kite_whitelist_checked = 1
   endif
@@ -56,4 +56,3 @@ function! kite#status#handler(buffer, response)
   call setbufvar(a:buffer, 'kite_status', json.status)
   redrawstatus
 endfunction
-

--- a/doc/kite.txt
+++ b/doc/kite.txt
@@ -17,14 +17,13 @@ using all the open source code on GitHub.
 Press |K| when your cursor is over a identifier to open a split window with
 documentation about the identifier. In addition to documentation, Kite also
 provides information about where you've used the identifier in your codebase,
-curated code examples showing you how to use the identifier, as well as links
-to common questions about the identifier on Stack Overflow.
+as well as curated code examples showing you how to use the identifier.
 
-3. Sidebar integration
+3. Copilot integration
 
-While you code in VIM, the Sidebar will automatically show you information
-about the code that you're currently working with. To open the Sidebar, click
-on the Kite menubar icon and select "Open Sidebar".
+While you code in VIM, the Copilot will automatically show you information
+about the code that you're currently working with. To open the Copilot, click
+on the Kite menubar icon and select "Open Copilot".
 
 To learn more about Kite and how to use the VIM plugin, visit our [help
 page](http://help.kite.com).


### PR DESCRIPTION
@airblade 

***PLEASE DO NOT MERGE***

Hi! I’m working on making our UI strings more consistent and in line with the new glossary (https://kite.quip.com/UN0rA3ZHruZF/Kite-glossary).

Please let me know whether this looks good, and maybe if I missed some obvious strings? Thank you.

(More info about this project: https://kite.quip.com/eGu8AecvGYze/New-UI-strings-deployment)