### PR TITLE
Improve startuptime by checking for /proc/version

### DIFF
--- a/autoload/kite/utils.vim
+++ b/autoload/kite/utils.vim
@@ -3,8 +3,7 @@
 if has('win64') || has('win32') || has('win32unix')
   let s:os = 'windows'
 else
-  let uname = substitute(system('uname'), '\n', '', '')  " Darwin or Linux
-  let s:os = uname ==? 'Darwin' ? 'macos' : 'linux'
+    let s:os = empty(findfile('/proc/version')) ? 'macos' : 'linux'
 endif
 
 function! kite#utils#windows()

--- a/autoload/kite/utils.vim
+++ b/autoload/kite/utils.vim
@@ -3,7 +3,7 @@
 if has('win64') || has('win32') || has('win32unix')
   let s:os = 'windows'
 else
-    let s:os = empty(findfile('/proc/version')) ? 'macos' : 'linux'
+    let s:os = empty(findfile('/sbin/launchd')) ? 'linux' : 'macos'
 endif
 
 function! kite#utils#windows()


### PR DESCRIPTION
As discussed in https://github.com/kiteco/vim-plugin/issues/156, this PR checks for the existence of /proc/version. This file only exists on Linux, so if it's not present, we can assume we're on MacOS (after checking for Windows).

Speed improvement on my machine with the latest version of nvim:
```bash
$ nvim --startuptime old.log
$ cat old.log | grep kite
116.585  042.795  042.795: sourcing /Users/Yochem/.config/nvim/pack/kite/start/vim-plugin/autoload/kite/utils.vim
117.168  000.271  000.271: sourcing /Users/Yochem/.config/nvim/pack/kite/start/vim-plugin/autoload/kite.vim
117.782  044.429  001.335: sourcing /Users/Yochem/.config/nvim/pack/kite/start/vim-plugin/plugin/kite.vim
```
with `let s:os = empty(findfile('/proc/version')) ? 'macos' : 'linux'`:
```bash
$ nvim --startuptime new.log
$ cat new.log | grep kite
216.054  001.232  001.232: sourcing /Users/Yochem/.config/nvim/pack/kite/start/vim-plugin/autoload/kite/utils.vim
219.305  002.942  002.942: sourcing /Users/Yochem/.config/nvim/pack/kite/start/vim-plugin/autoload/kite.vim
223.481  011.949  007.719: sourcing /Users/Yochem/.config/nvim/pack/kite/start/vim-plugin/plugin/kite.vim
```
So by checking for /proc/version sourcing the kite plugin is around 4x faster on my machine.