### PR TITLE
Lazily initialise plugin and launch kited

### DIFF
--- a/autoload/kite.vim
+++ b/autoload/kite.vim
@@ -1,6 +1,7 @@
 let s:status_poll_interval = 5 * 1000  " 5sec in milliseconds
 let s:plan_poll_interval = 30 * 1000  " 30sec in milliseconds
 let s:timer = -1
+let s:kite_auto_launched = 0
 
 
 function kite#enable_auto_start()
@@ -30,8 +31,6 @@ endfunction
 
 
 function! kite#init()
-  call s:launch_kited()
-
   if &pumheight == 0
     set pumheight=10
   endif
@@ -49,6 +48,8 @@ endfunction
 
 function! kite#bufenter()
   if s:supported_language()
+    call s:launch_kited()
+
     call s:setup_events()
     call s:setup_mappings()
 
@@ -187,8 +188,9 @@ endfunction
 
 
 function! s:launch_kited()
-  if kite#utils#get_setting('start_kited_at_startup', 1)
+  if !s:kite_auto_launched && kite#utils#get_setting('start_kited_at_startup', 1)
     call kite#utils#launch_kited()
+    let s:kite_auto_launched = 1
   endif
 endfunction
 

--- a/autoload/kite.vim
+++ b/autoload/kite.vim
@@ -1,6 +1,7 @@
 let s:status_poll_interval = 5 * 1000  " 5sec in milliseconds
 let s:plan_poll_interval = 30 * 1000  " 30sec in milliseconds
 let s:timer = -1
+let s:inited = 0
 let s:kite_auto_launched = 0
 
 
@@ -30,7 +31,11 @@ function! kite#max_file_size()
 endfunction
 
 
-function! kite#init()
+function! s:init()
+  if s:inited
+    return
+  endif
+
   if &pumheight == 0
     set pumheight=10
   endif
@@ -41,13 +46,22 @@ function! kite#init()
 
   set shortmess+=c
 
+  if kite#utils#windows()
+    " Avoid taskbar flashing on Windows when executing system() calls.
+    set noshelltemp
+  endif
+
   call s:configure_completeopt()
   call s:start_plan_timer()
+
+  let s:inited = 1
 endfunction
 
 
 function! kite#bufenter()
   if s:supported_language()
+    call s:init()
+
     call s:launch_kited()
 
     call s:setup_events()

--- a/plugin/kite.vim
+++ b/plugin/kite.vim
@@ -37,13 +37,6 @@ if !(has('nvim') || has('timers'))
   finish
 endif
 
-if kite#utils#windows()
-  " Avoid taskbar flashing on Windows when executing system() calls.
-  set noshelltemp
-endif
-
-call kite#init()
-
 augroup Kite
   autocmd!
   autocmd BufEnter * call kite#bufenter()


### PR DESCRIPTION
These commits delay initialising the plugin and launching kited until the first Python file is opened, instead of doing all that work when Vim is opened (quite possibly with a non-Python file).

This keeps Vim's startup nice and speedy.