### PR TITLE
Make kite status fail safe.

### DIFF
--- a/autoload/kite/status.vim
+++ b/autoload/kite/status.vim
@@ -41,6 +41,7 @@ function! kite#status#handler(buffer, response)
 
   " indexing | syncing | ready
   let status = json.status
+  let msg = ''
 
   if status == 'ready'
     let msg = 'Kite'


### PR DESCRIPTION
If kited returns an unexpected status, fall back to an empty string
instead of throwing an error.

See #159.