### PR TITLE
New completions API

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ let g:kite_auto_complete=0
 
 You can manually invoke the completions in insert mode with `<C-X><C-U>`.  See `:h i_CTRL-X_CTRL-U` for details.
 
+Kite's completions include snippets by default.  To opt out of the snippets, add this to your vimrc:
+
+```viml
+let g:kite_snippets=0
+```
+
 Normally you insert the currently selected completion option with `<C-y>`.  If you'd like to use `<Tab>` instead / as well, add this to your vimrc:
 
 ```viml

--- a/README.md
+++ b/README.md
@@ -70,6 +70,20 @@ set belloff+=ctrlg  " if vim beeps during completion
 ```
 
 
+#### Placeholders
+
+Some completions have placeholders which can be filled in.  These will be highlighted with the Underline highlight group.
+
+You can navigate between placeholders with `<CTRL-J>` (forward) and `<CTRL-K>` (backward), even after you have typed over the original placeholder text.
+
+To change these keys:
+
+```viml
+let g:kite_previous_placeholder = '<C-H>'
+let g:kite_next_placeholder = '<C-L>`
+```
+
+
 ### Signatures
 
 Kite can show how other people used the signature you are using.  By default this is off to save space.

--- a/autoload/kite.vim
+++ b/autoload/kite.vim
@@ -106,6 +106,8 @@ function s:setup_events()
     autocmd InsertCharPre            <buffer> call kite#completion#insertcharpre()
     autocmd TextChangedI             <buffer> call kite#completion#autocomplete()
 
+    autocmd CompleteDone             <buffer> call kite#snippet#complete_done()
+
     if exists('g:kite_documentation_continual') && g:kite_documentation_continual
       autocmd CursorHold,CursorHoldI <buffer> call kite#docs#docs()
     endif
@@ -159,6 +161,13 @@ function! s:setup_mappings()
   if empty(maparg('K', 'n')) && !hasmapto('(kite-docs)', 'n')
     nmap <silent> <buffer> K <Plug>(kite-docs)
   endif
+
+
+  nnoremap <C-j> :<c-u>call kite#snippet#next_placeholder()<cr>
+  nnoremap <C-k> :<c-u>call kite#snippet#previous_placeholder()<cr>
+  vnoremap <C-j> :<c-u>call kite#snippet#next_placeholder()<cr>
+  vnoremap <C-k> :<c-u>call kite#snippet#previous_placeholder()<cr>
+
 endfunction
 
 

--- a/autoload/kite.vim
+++ b/autoload/kite.vim
@@ -163,11 +163,15 @@ function! s:setup_mappings()
   endif
 
 
-  nnoremap <C-j> :<c-u>call kite#snippet#next_placeholder()<cr>
-  nnoremap <C-k> :<c-u>call kite#snippet#previous_placeholder()<cr>
-  vnoremap <C-j> :<c-u>call kite#snippet#next_placeholder()<cr>
-  vnoremap <C-k> :<c-u>call kite#snippet#previous_placeholder()<cr>
+  inoremap <silent> <c-j> <c-\><c-o>:call kite#snippet#next_placeholder()<cr>
+  inoremap <silent> <c-k> <c-\><c-o>:call kite#snippet#previous_placeholder()<cr>
+  snoremap <silent> <c-j> <esc>:call kite#snippet#next_placeholder()<cr>
+  snoremap <silent> <c-k> <esc>:call kite#snippet#previous_placeholder()<cr>
 
+  " snoremap <silent> <bs> <c-g>c
+  " snoremap <silent> <del> <c-g>c
+  " snoremap <silent> <c-h> <c-g>c
+  " snoremap <silent> <c-r> <c-g>"_c<c-r>
 endfunction
 
 

--- a/autoload/kite.vim
+++ b/autoload/kite.vim
@@ -161,17 +161,6 @@ function! s:setup_mappings()
   if empty(maparg('K', 'n')) && !hasmapto('(kite-docs)', 'n')
     nmap <silent> <buffer> K <Plug>(kite-docs)
   endif
-
-
-  inoremap <silent> <c-j> <c-\><c-o>:call kite#snippet#next_placeholder()<cr>
-  inoremap <silent> <c-k> <c-\><c-o>:call kite#snippet#previous_placeholder()<cr>
-  snoremap <silent> <c-j> <esc>:call kite#snippet#next_placeholder()<cr>
-  snoremap <silent> <c-k> <esc>:call kite#snippet#previous_placeholder()<cr>
-
-  " snoremap <silent> <bs> <c-g>c
-  " snoremap <silent> <del> <c-g>c
-  " snoremap <silent> <c-h> <c-g>c
-  " snoremap <silent> <c-r> <c-g>"_c<c-r>
 endfunction
 
 

--- a/autoload/kite/client.vim
+++ b/autoload/kite/client.vim
@@ -90,7 +90,7 @@ endfunction
 
 
 function! kite#client#completions(json, handler)
-  let path = s:editor_path.'/completions'
+  let path = s:editor_path.'/complete'
   if has('channel')
     call s:async(function('s:timer_post', [path, g:kite_long_timeout, a:json, a:handler]))
   else

--- a/autoload/kite/completion.vim
+++ b/autoload/kite/completion.vim
@@ -31,6 +31,13 @@ function! kite#completion#autocomplete()
   if wordcount().bytes > kite#max_file_size() | return | endif
 
   if s:should_trigger_completion
+
+    echom 'autocomplete unmap'
+    silent! iunmap <buffer> <C-J>
+    silent! iunmap <buffer> <C-K>
+    silent! sunmap <buffer> <C-J>
+    silent! sunmap <buffer> <C-K>
+
     let s:should_trigger_completion = 0
     call feedkeys("\<C-X>\<C-U>")
   endif

--- a/autoload/kite/completion.vim
+++ b/autoload/kite/completion.vim
@@ -90,7 +90,11 @@ function! s:get_completions()
         \   'filename':     filename,
         \   'editor':       'vim',
         \   'text':         s:text,
-        \   'cursor_runes': s:cursor
+        \   'position': {
+        \     'begin': s:cursor,
+        \     'end':   s:cursor
+        \   },
+        \   'placeholders': []
         \ }
 
   let json = json_encode(params)
@@ -143,9 +147,9 @@ function! kite#completion#handler(counter, startcol, response) abort
       let hint = repeat(' ', hint_len - strlen(hint)).hint
     endif
     call add(matches, {
-          \     'word': c.insert,
+          \     'word': c.snippet.text,
           \     'abbr': c.display,
-          \     'info': c.documentation_text,
+          \     'info': c.documentation.text,
           \     'menu': hint
           \   })
   endfor

--- a/autoload/kite/completion.vim
+++ b/autoload/kite/completion.vim
@@ -190,8 +190,6 @@ function! s:adapt(completion_option, max_hint_length, nesting)
   let indent = repeat('  ', a:nesting)
 
   " FIXME user_data 8.0.1493
-  " assume they are ordered; if not: sort(placeholders, {x,y -> x.begin - y.begin})
-  " let b:kite_placeholders = a:completion_option.snippet.placeholders
 
   return {
         \   'word': a:completion_option.snippet.text,

--- a/autoload/kite/completion.vim
+++ b/autoload/kite/completion.vim
@@ -124,23 +124,21 @@ function! kite#completion#handler(counter, startcol, response) abort
     return
   endif
 
-  " FIXME
-  let json = json_decode(join(readfile('/Users/andy/code/src/kite-vim-plugin/kite-completions-dumps.json'), "\n"))
-  " " Ignore old completion results.
-  " if a:counter != s:completion_counter
-  "   return
-  " endif
+  " Ignore old completion results.
+  if a:counter != s:completion_counter
+    return
+  endif
 
-  " if a:response.status != 200
-  "   return
-  " endif
+  if a:response.status != 200
+    return
+  endif
 
-  " " This should not happen but evidently it sometimes does (#107).
-  " if empty(a:response.body)
-  "   return
-  " endif
+  " This should not happen but evidently it sometimes does (#107).
+  if empty(a:response.body)
+    return
+  endif
 
-  " let json = json_decode(a:response.body)
+  let json = json_decode(a:response.body)
 
   " API should return 404 status when no completions but it sometimes
   " return 200 status and an empty response body, or "completions":"null".

--- a/autoload/kite/completion.vim
+++ b/autoload/kite/completion.vim
@@ -32,7 +32,8 @@ function! kite#completion#autocomplete()
 
   if s:should_trigger_completion
 
-    echom 'autocomplete unmap'
+    " todo DRY
+    echom 'about to autocomplete; unmap'
     silent! iunmap <buffer> <C-J>
     silent! iunmap <buffer> <C-K>
     silent! sunmap <buffer> <C-J>

--- a/autoload/kite/completion.vim
+++ b/autoload/kite/completion.vim
@@ -105,6 +105,7 @@ function! s:get_completions()
           \ }
   else
     let params = {
+          \   'no_snippets':  (g:kite_snippets ? v:false : v:true),
           \   'filename':     filename,
           \   'editor':       'vim',
           \   'text':         s:text,

--- a/autoload/kite/completion.vim
+++ b/autoload/kite/completion.vim
@@ -198,6 +198,7 @@ function! s:adapt(completion_option, max_hint_length, nesting)
         \   'abbr': indent.a:completion_option.display,
         \   'info': a:completion_option.documentation.text,
         \   'menu': hint,
+        \   'equal': 1,
         \   'user_data': json_encode(a:completion_option.snippet.placeholders)
         \ }
 endfunction

--- a/autoload/kite/completion.vim
+++ b/autoload/kite/completion.vim
@@ -86,16 +86,25 @@ function! s:get_completions()
 
   let filename = kite#utils#filepath(0)
 
-  let params = {
-        \   'filename':     filename,
-        \   'editor':       'vim',
-        \   'text':         s:text,
-        \   'position': {
-        \     'begin': s:cursor,
-        \     'end':   s:cursor
-        \   },
-        \   'placeholders': []
-        \ }
+  if s:signature
+    let params = {
+          \   'filename':     filename,
+          \   'editor':       'vim',
+          \   'text':         s:text,
+          \   'cursor_runes': s:cursor
+          \ }
+  else
+    let params = {
+          \   'filename':     filename,
+          \   'editor':       'vim',
+          \   'text':         s:text,
+          \   'position': {
+          \     'begin': s:cursor,
+          \     'end':   s:cursor
+          \   },
+          \   'placeholders': []
+          \ }
+  endif
 
   let json = json_encode(params)
 

--- a/autoload/kite/completion.vim
+++ b/autoload/kite/completion.vim
@@ -31,14 +31,6 @@ function! kite#completion#autocomplete()
   if wordcount().bytes > kite#max_file_size() | return | endif
 
   if s:should_trigger_completion
-
-    " todo DRY
-    echom 'about to autocomplete; unmap'
-    silent! iunmap <buffer> <C-J>
-    silent! iunmap <buffer> <C-K>
-    silent! sunmap <buffer> <C-J>
-    silent! sunmap <buffer> <C-K>
-
     let s:should_trigger_completion = 0
     call feedkeys("\<C-X>\<C-U>")
   endif

--- a/autoload/kite/signature.vim
+++ b/autoload/kite/signature.vim
@@ -174,6 +174,7 @@ function! kite#signature#handler(counter, startcol, response) abort
               \   'word':  '',
               \   'abbr':  indent.line,
               \   'empty': 1,
+              \   'equal': 1,
               \   'dup':   1
               \ }
         call add(completions, completion)

--- a/autoload/kite/snippet.vim
+++ b/autoload/kite/snippet.vim
@@ -279,8 +279,8 @@ endfunction
 function! s:setup_maps()
   execute 'inoremap <buffer> <silent> <expr>' g:kite_next_placeholder     'pumvisible() ? "<C-Y>"                                                         : "<C-\><C-O>:call kite#snippet#next_placeholder()<CR>"'
   execute 'inoremap <buffer> <silent> <expr>' g:kite_previous_placeholder 'pumvisible() ? "<C-Y><C-G>:<C-U>call kite#snippet#previous_placeholder(2)<CR>" : "<C-\><C-O>:call kite#snippet#previous_placeholder()<CR>"'
-  execute 'snoremap <buffer> <silent>' g:kite_next_placeholder     '<Esc>:call kite#snippet#next_placeholder()<CR>'
-  execute 'snoremap <buffer> <silent>' g:kite_previous_placeholder '<Esc>:call kite#snippet#previous_placeholder()<CR>'
+  execute 'snoremap <buffer> <silent>'        g:kite_next_placeholder     '<Esc>:call kite#snippet#next_placeholder()<CR>'
+  execute 'snoremap <buffer> <silent>'        g:kite_previous_placeholder '<Esc>:call kite#snippet#previous_placeholder()<CR>'
 
   call s:remove_smaps_for_printable_characters()
 endfunction

--- a/autoload/kite/snippet.vim
+++ b/autoload/kite/snippet.vim
@@ -112,10 +112,10 @@ endfunction
 
 
 function! s:setup_maps()
-  inoremap <buffer> <silent> <C-j> <C-\><C-O>:call kite#snippet#next_placeholder()<CR>
-  inoremap <buffer> <silent> <C-k> <C-\><C-O>:call kite#snippet#previous_placeholder()<CR>
-  snoremap <buffer> <silent> <C-j> <Esc>:call kite#snippet#next_placeholder()<CR>
-  snoremap <buffer> <silent> <C-k> <Esc>:call kite#snippet#previous_placeholder()<CR>
+  inoremap <buffer> <silent> <C-J> <C-\><C-O>:call kite#snippet#next_placeholder()<CR>
+  inoremap <buffer> <silent> <C-K> <C-\><C-O>:call kite#snippet#previous_placeholder()<CR>
+  snoremap <buffer> <silent> <C-J> <Esc>:call kite#snippet#next_placeholder()<CR>
+  snoremap <buffer> <silent> <C-K> <Esc>:call kite#snippet#previous_placeholder()<CR>
 
   call s:remove_smaps_for_printable_characters()
 endfunction
@@ -174,10 +174,10 @@ endfunction
 
 
 function! s:teardown_maps()
-  iunmap <buffer> <C-j>
-  iunmap <buffer> <C-k>
-  sunmap <buffer> <C-j>
-  sunmap <buffer> <C-k>
+  iunmap <buffer> <C-J>
+  iunmap <buffer> <C-K>
+  sunmap <buffer> <C-J>
+  sunmap <buffer> <C-K>
 endfunction
 
 

--- a/autoload/kite/snippet.vim
+++ b/autoload/kite/snippet.vim
@@ -1,160 +1,85 @@
 function! kite#snippet#complete_done()
-  if empty(v:completed_item)
-    return
-  endif
+  if empty(v:completed_item) | return | endif
 
-  " Ensure sorted
-  let placeholders = sort(json_decode(v:completed_item.user_data), {x,y -> x.begin - y.begin})
-
-  echo len(placeholders) . ' placeholder(s)'
-
-  if empty(placeholders)
-    return
-  endif
-
+  " If we have just completed a placeholder (as opposed to a 'top level'
+  " completion) move to the next placeholder.
   if exists('b:kite_placeholders') && !empty(b:kite_placeholders)
-    " Avoid nesting for now.
-    return
+    return kite#snippet#next_placeholder()
   endif
 
-
+  let placeholders = sort(json_decode(v:completed_item.user_data), {x,y -> x.begin - y.begin})
   let b:kite_placeholders = placeholders
 
+  if empty(placeholders) | return | endif
 
-  " The entire signature is inserted.
+  " Calculate column number of start of each placeholder.
   let inserted_text = v:completed_item.word
-  let w = strdisplaywidth(inserted_text)  " todo maybe use characters / bytes?
-  " start of inserted text
-  let insertion_start = col('.') - w
-
-
-  call clearmatches()
-  let linenr = line('.')
+  let insertion_start = col('.') - strdisplaywidth(inserted_text)
 
   for ph in placeholders
     let ph.col_begin = insertion_start + ph.begin
   endfor
 
-  " let i = 0
+  " Highlight placeholders.
+  call clearmatches()
   for ph in placeholders
-    " match by location (doesn't move when text moves)
-    " call matchaddpos('Underlined', [[linenr, ph.col_begin, ph.end - ph.begin]])
-
-    " marks update automatically when the text changes - but only the line
-    " number, not the column :(
-    " let letter = nr2char(char2nr('a') + i)
-    " call setpos("'".letter, [0, linenr, ph.col_begin])
-    " let i += 1
-
-    " match by regex (moves with text)
-    let placeholder_text = strcharpart(inserted_text, ph.begin, ph.end - ph.begin)
-    let ph.text = placeholder_text
-    call matchadd('Underlined', '\V\%'.linenr.'l'.escape(placeholder_text, '\'))
-
-    " or perhaps think of placeholders as holes in the overall completion
-    " then navigate between the non-hole parts?
+    call matchaddpos('Underlined', [[linenr, ph.col_begin, ph.end - ph.begin]])
   endfor
 
-
-
-  " once a placeholder has been filled in, do we need to be able to navigate
-  " to it?
-
-
-  normal! ^
-  let b:kite_placeholder = -1
-  call kite#snippet#next_placeholder()
-
-
-
-  " " now trigger (non-signature) completion for placeholder
-  " " to do this i think we need to delete the placeholder first
-  " execute 'normal! '.offset.'h'
-  " execute 'normal!'.(placeholders[0].end - placeholders[0].begin).'x'
-
-  " " now trigger (non-signature) completion for placeholder
-  " " with placeholder range
-  " call kite#completion#snippet(placeholders[0].begin, placeholders[0].end)
+  " Move to first placeholder.
+  call s:placeholder(0)
 endfunction
 
 
 
-"
-" maybe keep track of current placeholder; then we can just go the next
-"
-" if we are moving via regex, what do we do when two placeholders have same
-" regex e.g. "..." - how do we know which one we are on?
-"
-" use search() for regex-based navigation
-"
-"
-" moves to next placholder and selects it
 function! kite#snippet#next_placeholder()
-  if !exists('b:kite_placeholders') | return | endif
-  if !exists('b:kite_placeholder')  | return | endif
+  if !exists('b:kite_placeholders')       | return | endif
+  if !exists('b:kite_placeholder_index')  | return | endif
 
-  " let col = col('v')
-  " for i in range(len(b:kite_placeholders))
-  "   let ph = b:kite_placeholders[i]
-  "   if ph.col_begin > col
-  "     call s:placeholder(i)
-  "     return
-  "   endif
-  " endfor
+  " Adjust current and subsequent placeholders for the amount of text entered
+  " at the placeholder we are leaving.
 
-  " echom b:kite_placeholder
-  if b:kite_placeholder == len(b:kite_placeholders) - 1
-    return
-  endif
+  let line_length_delta = col('$') - b:kite_line_length
 
-  let b:kite_placeholder += 1
-  call s:placeholder(b:kite_placeholder, 1)
+  " current placeholder
+  let ph = b:kite_placeholders[b:kite_placeholder_index]
+  let ph.end += line_length_delta
+
+  " subsequent placeholders
+  for ph in b:kite_placeholders[b:kite_placeholder_index+1:]
+    let ph.col_begin += line_length_delta
+  endfor
+
+  call s:placeholder(b:kite_placeholder_index + 1)
 endfunction
-
 
 
 
 function! kite#snippet#previous_placeholder()
-  if !exists('b:kite_placeholders') | return | endif
-  if !exists('b:kite_placeholder')  | return | endif
+  if !exists('b:kite_placeholders')       | return | endif
+  if !exists('b:kite_placeholder_index')  | return | endif
 
-  " let col = col('v')
-  " for i in range(len(b:kite_placeholders) - 1, 0, -1)
-  "   let ph = b:kite_placeholders[i]
-  "   if ph.col_begin < col
-  "     call s:placeholder(i)
-  "     return
-  "   endif
-  " endfor
-
-  " echom b:kite_placeholder
-  if b:kite_placeholder == 0
-    return
-  endif
-
-  let b:kite_placeholder -= 1
-  call s:placeholder(b:kite_placeholder, -1)
+  call s:placeholder(b:kite_placeholder_index - 1)
 endfunction
 
 
 
-function! s:placeholder(i, dir)
+function! s:placeholder(index)
   if !exists('b:kite_placeholders') | return | endif
+  if a:index < 0 || a:index >= len(b:kite_placeholders) | return | endif
 
-  let ph = b:kite_placeholders[a:i]
+  let b:kite_placeholder_index = a:index
+  let ph = b:kite_placeholders[a:index]
 
-  " call setpos("'<", [0, line('.'), ph.col_begin])
-  " call setpos("'>", [0, line('.'), ph.col_begin + ph.end - ph.begin - 1])
-  " " change to select mode
-  " " execute "normal! gv\<c-g>"
-  " normal! gv
+  " store line length before placeholder gets changed by user
+  let b:kite_line_length = col('$')
 
-  let result = search('\V\%'.line('.').'l'.escape(ph.text, '\'), (a:dir == -1 ? 'b' : '').'z', line('.'))
-  " if result == 0
-  "   if a:dir == -1
-  "     call kite#snippet#previous_placeholder()
-  "   else
-  "     call kite#snippet#next_placeholder()
-  "   endif
-  " endif
+  " insert mode -> normal mode
+  stopinsert
+
+  let linenr = line('.')
+  call setpos("'<", [0, linenr, ph.col_begin])
+  call setpos("'>", [0, linenr, ph.col_begin + ph.end - ph.begin - (mode() == 'n' ? 1 : 0)])
+  " normal mode -> visual mode -> select mode
+  execute "normal! gv\<c-g>"
 endfunction

--- a/autoload/kite/snippet.vim
+++ b/autoload/kite/snippet.vim
@@ -9,8 +9,12 @@ function! kite#snippet#complete_done()
 
   let placeholders = sort(json_decode(v:completed_item.user_data), {x,y -> x.begin - y.begin})
   let b:kite_placeholders = placeholders
+  let b:kite_linenr = line('.')
 
   if empty(placeholders) | return | endif
+
+  call s:setup_maps()
+  call s:setup_autocmds()
 
   " Calculate column number of start of each placeholder.
   let inserted_text = v:completed_item.word
@@ -18,12 +22,6 @@ function! kite#snippet#complete_done()
 
   for ph in placeholders
     let ph.col_begin = insertion_start + ph.begin
-  endfor
-
-  " Highlight placeholders.
-  call clearmatches()
-  for ph in placeholders
-    call matchaddpos('Underlined', [[linenr, ph.col_begin, ph.end - ph.begin]])
   endfor
 
   " Move to first placeholder.
@@ -36,19 +34,7 @@ function! kite#snippet#next_placeholder()
   if !exists('b:kite_placeholders')       | return | endif
   if !exists('b:kite_placeholder_index')  | return | endif
 
-  " Adjust current and subsequent placeholders for the amount of text entered
-  " at the placeholder we are leaving.
-
-  let line_length_delta = col('$') - b:kite_line_length
-
-  " current placeholder
-  let ph = b:kite_placeholders[b:kite_placeholder_index]
-  let ph.end += line_length_delta
-
-  " subsequent placeholders
-  for ph in b:kite_placeholders[b:kite_placeholder_index+1:]
-    let ph.col_begin += line_length_delta
-  endfor
+  call s:update_placeholder_locations()
 
   call s:placeholder(b:kite_placeholder_index + 1)
 endfunction
@@ -63,10 +49,13 @@ function! kite#snippet#previous_placeholder()
 endfunction
 
 
-
+" Move to the placeholder at index and select its text.
 function! s:placeholder(index)
   if !exists('b:kite_placeholders') | return | endif
   if a:index < 0 || a:index >= len(b:kite_placeholders) | return | endif
+
+  call s:clear_placeholder_highlights()
+  call s:highlight_placeholders()
 
   let b:kite_placeholder_index = a:index
   let ph = b:kite_placeholders[a:index]
@@ -82,4 +71,104 @@ function! s:placeholder(index)
   call setpos("'>", [0, linenr, ph.col_begin + ph.end - ph.begin - (mode() == 'n' ? 1 : 0)])
   " normal mode -> visual mode -> select mode
   execute "normal! gv\<c-g>"
+endfunction
+
+
+" Adjust current and subsequent placeholders for the amount of text entered
+" at the placeholder we are leaving.
+function! s:update_placeholder_locations()
+  if !exists('b:kite_line_length') | return | endif
+
+  let line_length_delta = col('$') - b:kite_line_length
+
+  " current placeholder
+  let ph = b:kite_placeholders[b:kite_placeholder_index]
+  let ph.end += line_length_delta
+
+  " subsequent placeholders
+  for ph in b:kite_placeholders[b:kite_placeholder_index+1:]
+    let ph.col_begin += line_length_delta
+  endfor
+
+  let b:kite_line_length = col('$')
+endfunction
+
+
+function! s:highlight_placeholders()
+  let linenr = line('.')
+  for ph in b:kite_placeholders
+    let ph.matchid = matchaddpos('Underlined', [[linenr, ph.col_begin, ph.end - ph.begin]])
+  endfor
+endfunction
+
+
+function! s:clear_placeholder_highlights()
+  for ph in b:kite_placeholders
+    if has_key(ph, 'matchid')
+      call matchdelete(ph.matchid)
+    endif
+  endfor
+endfunction
+
+
+function! s:setup_maps()
+  inoremap <buffer> <silent> <c-j> <c-\><c-o>:call kite#snippet#next_placeholder()<cr>
+  inoremap <buffer> <silent> <c-k> <c-\><c-o>:call kite#snippet#previous_placeholder()<cr>
+  snoremap <buffer> <silent> <c-j> <esc>:call kite#snippet#next_placeholder()<cr>
+  snoremap <buffer> <silent> <c-k> <esc>:call kite#snippet#previous_placeholder()<cr>
+
+  " snoremap <silent> <bs> <c-g>c
+  " snoremap <silent> <del> <c-g>c
+  " snoremap <silent> <c-h> <c-g>c
+  " snoremap <silent> <c-r> <c-g>"_c<c-r>
+endfunction
+
+
+function! s:teardowm_maps()
+  iunmap <buffer> <c-j>
+  iunmap <buffer> <c-k>
+  sunmap <buffer> <c-j>
+  sunmap <buffer> <c-k>
+endfunction
+
+
+function! s:setup_autocmds()
+  augroup KiteSnippets
+    autocmd! * <buffer>
+
+    autocmd CursorMovedI <buffer> call s:update_placeholder_locations() | call s:clear_placeholder_highlights() | call s:highlight_placeholders()
+    " TODO use <SID>?
+    autocmd CursorMoved,CursorMovedI <buffer> call kite#snippet#cursormoved()
+    " TODO use <SID>?
+    autocmd InsertLeave <buffer> call kite#snippet#insertleave()
+  augroup END
+endfunction
+
+
+function! s:teardown_autocmds()
+  autocmd! KiteSnippets * <buffer>
+endfunction
+
+
+function! s:teardown()
+  call s:clear_placeholder_highlights()
+  call s:teardowm_maps()
+  call s:teardown_autocmds()
+  unlet! b:kite_linenr b:kite_line_length b:kite_placeholder_index b:kite_placeholders
+endfunction
+
+
+function! kite#snippet#cursormoved()
+  if !exists('b:kite_linenr') | return | endif
+  if b:kite_linenr == line('.') | return | endif
+
+  call s:teardown()
+endfunction
+
+
+function! kite#snippet#insertleave()
+  " Modes established by experimentation.
+  if mode(1) !=# 's' && mode(1) !=# 'niI'
+    call s:teardown()
+  endif
 endfunction

--- a/autoload/kite/snippet.vim
+++ b/autoload/kite/snippet.vim
@@ -19,6 +19,7 @@ function! kite#snippet#complete_done()
   " Calculate column number of start of each placeholder.
   let inserted_text = v:completed_item.word
   let insertion_start = col('.') - strdisplaywidth(inserted_text)
+  let b:kite_insertion_end = col('.')
 
   for ph in placeholders
     let ph.col_begin = insertion_start + ph.begin
@@ -52,7 +53,16 @@ endfunction
 " Move to the placeholder at index and select its text.
 function! s:placeholder(index)
   if !exists('b:kite_placeholders') | return | endif
-  if a:index < 0 || a:index >= len(b:kite_placeholders) | return | endif
+
+  if a:index < 0 | return | endif
+
+  if a:index == len(b:kite_placeholders)
+    " go to end of original completion
+    call setpos('.', [0, b:kite_linenr, b:kite_insertion_end + col('$') - b:kite_line_length - 1])
+    call feedkeys('a')
+    call s:teardown()
+    return
+  endif
 
   call s:clear_placeholder_highlights()
   call s:highlight_placeholders()
@@ -222,7 +232,7 @@ function! s:teardown()
   call s:teardown_maps()
   call s:teardown_autocmds()
   call s:restore_smaps()
-  unlet! b:kite_linenr b:kite_line_length b:kite_placeholder_index b:kite_placeholders
+  unlet! b:kite_linenr b:kite_line_length b:kite_placeholder_index b:kite_placeholders b:kite_insertion_end
 endfunction
 
 

--- a/autoload/kite/snippet.vim
+++ b/autoload/kite/snippet.vim
@@ -7,7 +7,7 @@ function! kite#snippet#complete_done()
     return kite#snippet#next_placeholder()
   endif
 
-  let placeholders = sort(json_decode(v:completed_item.user_data), {x,y -> x.begin - y.begin})
+  let placeholders = json_decode(v:completed_item.user_data)
   let b:kite_placeholders = placeholders
   let b:kite_linenr = line('.')
 

--- a/autoload/kite/snippet.vim
+++ b/autoload/kite/snippet.vim
@@ -56,8 +56,10 @@ function! kite#snippet#complete_done()
     unlet ph.begin ph.end
   endfor
 
-  """"""""""
-  " todo move this into the push() function
+  " Update placeholder locations.
+  "
+  " todo move this into the push() function?
+  " note this is very similar to s:update_placeholder_locations()
   if !b:kite_stack.is_empty()
     " current placeholder which has just been completed
     let level = b:kite_stack.peek()
@@ -81,10 +83,8 @@ function! kite#snippet#complete_done()
       endfor
     endfor
   endif
-  """"""""""
 
   call b:kite_stack.push({'placeholders': placeholders, 'index': 0})
-  call s:debug_stack()
 
   " Move to first placeholder.
   call s:placeholder(0)
@@ -107,8 +107,6 @@ endfunction
 " Move to the placeholder at index and select its text.
 function! s:placeholder(index)
   let index = a:index
-
-  call s:debug_stack()
 
   let level = b:kite_stack.peek()
   let placeholders = level.placeholders
@@ -180,7 +178,6 @@ function! s:update_placeholder_locations()
   let ph.length += line_length_delta
 
   " subsequent placeholders at current level
-  let level = b:kite_stack.peek()
   for ph in level.placeholders[level.index+1:]
     let ph.col_begin += line_length_delta
   endfor
@@ -334,7 +331,6 @@ function! s:teardown()
   call kite#snippet#teardown_maps()
   call s:teardown_autocmds()
   call s:restore_smaps()
-  " call s:debug_stack()
   call b:kite_stack.empty()
   unlet! b:kite_linenr b:kite_line_length b:kite_insertion_end
 endfunction

--- a/autoload/kite/snippet.vim
+++ b/autoload/kite/snippet.vim
@@ -41,6 +41,7 @@ function! kite#snippet#complete_done()
   endif
 
   let b:kite_linenr = line('.')
+  let b:kite_line_length = col('$')
 
   call s:setup_maps()
   call s:setup_autocmds()

--- a/autoload/kite/snippet.vim
+++ b/autoload/kite/snippet.vim
@@ -363,7 +363,7 @@ endfunction
 
 function! s:insertleave()
   " Modes established by experimentation.
-  if mode(1) !=# 's' && mode(1) !=# 'niI'
+  if mode(1) !=# 's' && mode(1) !=# (has('patch-8.1.0225') ? 'niI' : 'n')
     call s:teardown()
   endif
 endfunction

--- a/autoload/kite/snippet.vim
+++ b/autoload/kite/snippet.vim
@@ -29,15 +29,41 @@ function! kite#snippet#complete_done()
 
 
   call clearmatches()
+  let linenr = line('.')
 
   for ph in placeholders
     let ph.col_begin = insertion_start + ph.begin
   endfor
 
+  " let i = 0
   for ph in placeholders
-    call matchaddpos('Underlined', [[line('.'), ph.col_begin, ph.end - ph.begin]])
+    " match by location (doesn't move when text moves)
+    " call matchaddpos('Underlined', [[linenr, ph.col_begin, ph.end - ph.begin]])
+
+    " marks update automatically when the text changes - but only the line
+    " number, not the column :(
+    " let letter = nr2char(char2nr('a') + i)
+    " call setpos("'".letter, [0, linenr, ph.col_begin])
+    " let i += 1
+
+    " match by regex (moves with text)
+    let placeholder_text = strcharpart(inserted_text, ph.begin, ph.end - ph.begin)
+    let ph.text = placeholder_text
+    call matchadd('Underlined', '\V\%'.linenr.'l'.escape(placeholder_text, '\'))
+
+    " or perhaps think of placeholders as holes in the overall completion
+    " then navigate between the non-hole parts?
   endfor
-  " call matchaddpos('Underlined', map(copy(placeholders), {_,ph -> [line('.'), insertion_start + ph.begin, ph.end - ph.begin]}))
+
+
+
+  " once a placeholder has been filled in, do we need to be able to navigate
+  " to it?
+
+
+  normal! ^
+  let b:kite_placeholder = -1
+  call kite#snippet#next_placeholder()
 
 
 
@@ -53,39 +79,82 @@ endfunction
 
 
 
+"
+" maybe keep track of current placeholder; then we can just go the next
+"
+" if we are moving via regex, what do we do when two placeholders have same
+" regex e.g. "..." - how do we know which one we are on?
+"
+" use search() for regex-based navigation
+"
+"
 " moves to next placholder and selects it
 function! kite#snippet#next_placeholder()
-  let col = col('v')
-  for i in range(len(b:kite_placeholders))
-    let ph = b:kite_placeholders[i]
-    if ph.col_begin > col
-      call s:placeholder(i)
-      return
-    endif
-  endfor
+  if !exists('b:kite_placeholders') | return | endif
+  if !exists('b:kite_placeholder')  | return | endif
+
+  " let col = col('v')
+  " for i in range(len(b:kite_placeholders))
+  "   let ph = b:kite_placeholders[i]
+  "   if ph.col_begin > col
+  "     call s:placeholder(i)
+  "     return
+  "   endif
+  " endfor
+
+  " echom b:kite_placeholder
+  if b:kite_placeholder == len(b:kite_placeholders) - 1
+    return
+  endif
+
+  let b:kite_placeholder += 1
+  call s:placeholder(b:kite_placeholder, 1)
 endfunction
+
 
 
 
 function! kite#snippet#previous_placeholder()
-  let col = col('v')
-  for i in range(len(b:kite_placeholders) - 1, 0, -1)
-    let ph = b:kite_placeholders[i]
-    if ph.col_begin < col
-      call s:placeholder(i)
-      return
-    endif
-  endfor
+  if !exists('b:kite_placeholders') | return | endif
+  if !exists('b:kite_placeholder')  | return | endif
+
+  " let col = col('v')
+  " for i in range(len(b:kite_placeholders) - 1, 0, -1)
+  "   let ph = b:kite_placeholders[i]
+  "   if ph.col_begin < col
+  "     call s:placeholder(i)
+  "     return
+  "   endif
+  " endfor
+
+  " echom b:kite_placeholder
+  if b:kite_placeholder == 0
+    return
+  endif
+
+  let b:kite_placeholder -= 1
+  call s:placeholder(b:kite_placeholder, -1)
 endfunction
 
 
 
-function! s:placeholder(i)
+function! s:placeholder(i, dir)
+  if !exists('b:kite_placeholders') | return | endif
+
   let ph = b:kite_placeholders[a:i]
 
-  call setpos("'<", [0, line('.'), ph.col_begin])
-  call setpos("'>", [0, line('.'), ph.col_begin + ph.end - ph.begin - 1])
-  " change to select mode
-  " execute "normal! gv\<c-g>"
-  normal! gv
+  " call setpos("'<", [0, line('.'), ph.col_begin])
+  " call setpos("'>", [0, line('.'), ph.col_begin + ph.end - ph.begin - 1])
+  " " change to select mode
+  " " execute "normal! gv\<c-g>"
+  " normal! gv
+
+  let result = search('\V\%'.line('.').'l'.escape(ph.text, '\'), (a:dir == -1 ? 'b' : '').'z', line('.'))
+  " if result == 0
+  "   if a:dir == -1
+  "     call kite#snippet#previous_placeholder()
+  "   else
+  "     call kite#snippet#next_placeholder()
+  "   endif
+  " endif
 endfunction

--- a/autoload/kite/snippet.vim
+++ b/autoload/kite/snippet.vim
@@ -112,23 +112,18 @@ endfunction
 
 
 function! s:setup_maps()
-  inoremap <buffer> <silent> <c-j> <c-\><c-o>:call kite#snippet#next_placeholder()<cr>
-  inoremap <buffer> <silent> <c-k> <c-\><c-o>:call kite#snippet#previous_placeholder()<cr>
-  snoremap <buffer> <silent> <c-j> <esc>:call kite#snippet#next_placeholder()<cr>
-  snoremap <buffer> <silent> <c-k> <esc>:call kite#snippet#previous_placeholder()<cr>
-
-  " snoremap <silent> <bs> <c-g>c
-  " snoremap <silent> <del> <c-g>c
-  " snoremap <silent> <c-h> <c-g>c
-  " snoremap <silent> <c-r> <c-g>"_c<c-r>
+  inoremap <buffer> <silent> <C-j> <C-\><C-O>:call kite#snippet#next_placeholder()<CR>
+  inoremap <buffer> <silent> <C-k> <C-\><C-O>:call kite#snippet#previous_placeholder()<CR>
+  snoremap <buffer> <silent> <C-j> <Esc>:call kite#snippet#next_placeholder()<CR>
+  snoremap <buffer> <silent> <C-k> <Esc>:call kite#snippet#previous_placeholder()<CR>
 endfunction
 
 
 function! s:teardowm_maps()
-  iunmap <buffer> <c-j>
-  iunmap <buffer> <c-k>
-  sunmap <buffer> <c-j>
-  sunmap <buffer> <c-k>
+  iunmap <buffer> <C-j>
+  iunmap <buffer> <C-k>
+  sunmap <buffer> <C-j>
+  sunmap <buffer> <C-k>
 endfunction
 
 
@@ -136,11 +131,12 @@ function! s:setup_autocmds()
   augroup KiteSnippets
     autocmd! * <buffer>
 
-    autocmd CursorMovedI <buffer> call s:update_placeholder_locations() | call s:clear_placeholder_highlights() | call s:highlight_placeholders()
-    " TODO use <SID>?
-    autocmd CursorMoved,CursorMovedI <buffer> call kite#snippet#cursormoved()
-    " TODO use <SID>?
-    autocmd InsertLeave <buffer> call kite#snippet#insertleave()
+    autocmd CursorMovedI <buffer>
+          \ call s:update_placeholder_locations() |
+          \ call s:clear_placeholder_highlights() |
+          \ call s:highlight_placeholders()
+    autocmd CursorMoved,CursorMovedI <buffer> call s:cursormoved()
+    autocmd InsertLeave              <buffer> call s:insertleave()
   augroup END
 endfunction
 
@@ -158,7 +154,7 @@ function! s:teardown()
 endfunction
 
 
-function! kite#snippet#cursormoved()
+function! s:cursormoved()
   if !exists('b:kite_linenr') | return | endif
   if b:kite_linenr == line('.') | return | endif
 
@@ -166,7 +162,7 @@ function! kite#snippet#cursormoved()
 endfunction
 
 
-function! kite#snippet#insertleave()
+function! s:insertleave()
   " Modes established by experimentation.
   if mode(1) !=# 's' && mode(1) !=# 'niI'
     call s:teardown()

--- a/autoload/kite/snippet.vim
+++ b/autoload/kite/snippet.vim
@@ -112,10 +112,10 @@ endfunction
 
 
 function! s:setup_maps()
-  inoremap <buffer> <silent> <C-J> <C-\><C-O>:call kite#snippet#next_placeholder()<CR>
-  inoremap <buffer> <silent> <C-K> <C-\><C-O>:call kite#snippet#previous_placeholder()<CR>
-  snoremap <buffer> <silent> <C-J> <Esc>:call kite#snippet#next_placeholder()<CR>
-  snoremap <buffer> <silent> <C-K> <Esc>:call kite#snippet#previous_placeholder()<CR>
+  execute 'inoremap <buffer> <silent>' g:kite_next_placeholder     '<C-\><C-O>:call kite#snippet#next_placeholder()<CR>'
+  execute 'inoremap <buffer> <silent>' g:kite_previous_placeholder '<C-\><C-O>:call kite#snippet#previous_placeholder()<CR>'
+  execute 'snoremap <buffer> <silent>' g:kite_next_placeholder     '<Esc>:call kite#snippet#next_placeholder()<CR>'
+  execute 'snoremap <buffer> <silent>' g:kite_previous_placeholder '<Esc>:call kite#snippet#previous_placeholder()<CR>'
 
   call s:remove_smaps_for_printable_characters()
 endfunction

--- a/autoload/kite/snippet.vim
+++ b/autoload/kite/snippet.vim
@@ -153,8 +153,6 @@ function! s:remove_smaps_for_printable_characters()
         \ '<LocalLeader>'
         \ ]
 
-  " https://vi.stackexchange.com/questions/7734/how-to-save-and-restore-a-mapping
-
   " Get a list of maps active in select mode.
   for scope in ['<buffer>', '']
     redir => maps | silent execute 'smap' scope | redir END

--- a/autoload/kite/snippet.vim
+++ b/autoload/kite/snippet.vim
@@ -199,7 +199,7 @@ endfunction
 function! s:highlight_current_level_placeholders()
   let linenr = line('.')
   for ph in b:kite_stack.peek().placeholders
-    let ph.matchid = matchaddpos('Underlined', [[linenr, ph.col_begin, ph.length]])
+    let ph.matchid = matchaddpos('Special', [[linenr, ph.col_begin, ph.length]])
   endfor
 endfunction
 

--- a/autoload/kite/snippet.vim
+++ b/autoload/kite/snippet.vim
@@ -1,0 +1,91 @@
+function! kite#snippet#complete_done()
+  if empty(v:completed_item)
+    return
+  endif
+
+  " Ensure sorted
+  let placeholders = sort(json_decode(v:completed_item.user_data), {x,y -> x.begin - y.begin})
+
+  echo len(placeholders) . ' placeholder(s)'
+
+  if empty(placeholders)
+    return
+  endif
+
+  if exists('b:kite_placeholders') && !empty(b:kite_placeholders)
+    " Avoid nesting for now.
+    return
+  endif
+
+
+  let b:kite_placeholders = placeholders
+
+
+  " The entire signature is inserted.
+  let inserted_text = v:completed_item.word
+  let w = strdisplaywidth(inserted_text)  " todo maybe use characters / bytes?
+  " start of inserted text
+  let insertion_start = col('.') - w
+
+
+  call clearmatches()
+
+  for ph in placeholders
+    let ph.col_begin = insertion_start + ph.begin
+  endfor
+
+  for ph in placeholders
+    call matchaddpos('Underlined', [[line('.'), ph.col_begin, ph.end - ph.begin]])
+  endfor
+  " call matchaddpos('Underlined', map(copy(placeholders), {_,ph -> [line('.'), insertion_start + ph.begin, ph.end - ph.begin]}))
+
+
+
+  " " now trigger (non-signature) completion for placeholder
+  " " to do this i think we need to delete the placeholder first
+  " execute 'normal! '.offset.'h'
+  " execute 'normal!'.(placeholders[0].end - placeholders[0].begin).'x'
+
+  " " now trigger (non-signature) completion for placeholder
+  " " with placeholder range
+  " call kite#completion#snippet(placeholders[0].begin, placeholders[0].end)
+endfunction
+
+
+
+" moves to next placholder and selects it
+function! kite#snippet#next_placeholder()
+  let col = col('v')
+  for i in range(len(b:kite_placeholders))
+    let ph = b:kite_placeholders[i]
+    if ph.col_begin > col
+      call s:placeholder(i)
+      return
+    endif
+  endfor
+endfunction
+
+
+
+function! kite#snippet#previous_placeholder()
+  let col = col('v')
+  for i in range(len(b:kite_placeholders) - 1, 0, -1)
+    let ph = b:kite_placeholders[i]
+    if ph.col_begin < col
+      call s:placeholder(i)
+      return
+    endif
+  endfor
+endfunction
+
+
+
+function! s:placeholder(i)
+  let ph = b:kite_placeholders[a:i]
+
+  call setpos("'<", [0, line('.'), ph.col_begin])
+  call setpos("'>", [0, line('.'), ph.col_begin + ph.end - ph.begin - 1])
+  " change to select mode
+  " execute "normal! gv\<c-g>"
+  normal! gv
+endfunction

--- a/autoload/kite/snippet.vim
+++ b/autoload/kite/snippet.vim
@@ -357,6 +357,8 @@ function! s:cursormoved()
   if !exists('b:kite_linenr') | return | endif
   if b:kite_linenr == line('.') | return | endif
 
+  " TODO check whether the cursor is outside the bounds of the completion?
+
   call s:teardown()
 endfunction
 

--- a/plugin/kite.vim
+++ b/plugin/kite.vim
@@ -11,6 +11,10 @@ if !exists('g:kite_auto_complete')
   let g:kite_auto_complete = 1
 endif
 
+if !exists('g:kite_snippets')
+  let g:kite_snippets = 1
+endif
+
 if !exists('g:kite_previous_placeholder')
   let g:kite_previous_placeholder = '<C-K>'
 endif

--- a/plugin/kite.vim
+++ b/plugin/kite.vim
@@ -11,6 +11,14 @@ if !exists('g:kite_auto_complete')
   let g:kite_auto_complete = 1
 endif
 
+if !exists('g:kite_previous_placeholder')
+  let g:kite_previous_placeholder = '<C-K>'
+endif
+
+if !exists('g:kite_next_placeholder')
+  let g:kite_next_placeholder = '<C-J>'
+endif
+
 if !exists('g:kite_documentation_continual')
   let g:kite_documentation_continual = 0
 endif

--- a/test/editor_json_tests_runner.vim
+++ b/test/editor_json_tests_runner.vim
@@ -351,7 +351,7 @@ endif
 let features = json_decode(join(readfile(f), ''))
 
 for feature in features
-  let tests = glob(File('tests', feature, '*.json'), 1, 1)
+  let tests = glob(File('tests', feature, '**', '*.json'), 1, 1)
   for test in tests
     " if test !~ 'completions_new_spec/any/all' | continue | endif  " TODO remove this
     call RunTest(test)


### PR DESCRIPTION
This is a work-in-progress implementation of the new completions API (#160).  Feedback welcome!

When you accept a "top level" completion with placeholders:

- all placeholders are highlighted;
- the first placeholder is selected, ready for you to type over the default text;
- you can jump to the next placeholder with `ctrl-j` (and to the previous with `ctrl-k`);
- you can still jump to a placeholder which has been over-typed;
- placeholders "deactivate" as soon as you leave insert mode.

I haven't yet implemented the automatic triggering of a placeholder completion request when you navigate to an unamended placeholder.

This implementation keeps track of the placeholders' begin and end locations, even as the placeholder text is amended by the user.  This means we can revisit amended placeholders, and avoids the problems of search-based navigation (false positives and false negatives).

The code takes care of removing any select-mode mappings for printable characters, as per the recommendation in Vim's docs, and does its best to restore them once the placeholders are deactivated.  However the restoration doesn't work well yet.

To do:

- [ ] Automatic unamended-placeholder completion request.
- [x] Placeholders within placeholders...
- [x] Get the restoration of select-mode mappings working.
- [x] The cursor should jump to the end of the completion when navigating forward from the final placeholder.

Do we want to make the placeholder navigation (`ctrl-j`, `ctrl-k`) configurable?
