### PR TITLE
Implement onboarding

### DIFF
--- a/autoload/kite/client.vim
+++ b/autoload/kite/client.vim
@@ -2,6 +2,7 @@ let s:port               = empty($KITED_TEST_PORT) ? 46624 : $KITED_TEST_PORT
 let s:channel_base       = 'localhost:'.s:port
 let s:base_url           = 'http://127.0.0.1:'.s:port
 let s:editor_path        = '/clientapi/editor'
+let s:onboarding_path    = '/clientapi/plugins/onboarding_file?editor=vim'
 let s:hover_path         = '/api/buffer/vim'
 let s:docs_path          = 'kite://docs/'
 let s:status_path        = '/clientapi/status?filename='
@@ -45,6 +46,17 @@ endfunction
 
 function! kite#client#logged_in(handler)
   let path = s:user_path
+  if has('channel')
+    let response = s:internal_http(path, g:kite_short_timeout)
+  else
+    let response = s:external_http(s:base_url.path, g:kite_short_timeout)
+  endif
+  return a:handler(s:parse_response(response))
+endfunction
+
+
+function! kite#client#onboarding_file(handler)
+  let path = s:onboarding_path
   if has('channel')
     let response = s:internal_http(path, g:kite_short_timeout)
   else

--- a/autoload/kite/client.vim
+++ b/autoload/kite/client.vim
@@ -14,22 +14,22 @@ let s:permissions_path   = 'kite://settings/permissions'
 
 function! kite#client#docs(word)
   let url = s:docs_path.a:word
-  call s:open_kite_url(url)
+  call kite#utils#browse(url)
 endfunction
 
 
 function! kite#client#settings()
-  call s:open_kite_url(s:settings_path)
+  call kite#utils#browse(s:settings_path)
 endfunction
 
 
 function! kite#client#permissions()
-  call s:open_kite_url(s:permissions_path)
+  call kite#utils#browse(s:permissions_path)
 endfunction
 
 
 function! kite#client#copilot()
-  call s:open_kite_url(s:copilot_path)
+  call kite#utils#browse(s:copilot_path)
 endfunction
 
 
@@ -263,16 +263,6 @@ endfunction
 
 
 let s:http_binary = kite#utils#lib('kite-http')
-
-
-function! s:open_kite_url(url)
-  if kite#utils#windows()
-    let cmd = 'cmd /c start "" "'.a:url.'"'
-  else
-    let cmd = 'open "'.a:url.'"'
-  endif
-  silent call system(cmd)
-endfunction
 
 
 if !empty($KITED_TEST_PORT)

--- a/autoload/kite/onboarding.vim
+++ b/autoload/kite/onboarding.vim
@@ -59,7 +59,7 @@ endfunction
 
 function! s:handle_choice(index)
   if a:index == 0  " learn now
-    call kite#utils#browse('https://kite.com')
+    call kite#utils#browse('https://help.kite.com/category/47-vim-integration')
   elseif a:index == 2  " hide forever
     call kite#utils#set_setting(s:option, 0)
   endif

--- a/autoload/kite/onboarding.vim
+++ b/autoload/kite/onboarding.vim
@@ -1,0 +1,81 @@
+let s:text = [
+      \ 'Kite is now integrated with Vim',
+      \ '',
+      \ 'Kite is an AI-powered programming assistant',
+      \ 'that shows you the right information at the right',
+      \ 'time to keep you in the flow.',
+      \ '',
+      \ 'Please choose:',
+      \ '',
+      \ 'Learn how to use Kite',
+      \ 'Hide',
+      \ 'Hide forever',
+      \ ]
+let s:option = 'onboarding_required'
+
+
+function! kite#onboarding#call()
+  if !kite#utils#get_setting(s:option, 1)
+    return
+  endif
+
+  call kite#client#onboarding_file(function('kite#onboarding#handler'))
+endfunction
+
+
+function! kite#onboarding#handler(response) abort
+  if a:response.status == 200
+    silent execute 'tabedit' s:trim(a:response.body, '"')
+    call kite#utils#set_setting(s:option, 0)
+
+  else
+    if exists('*popup_menu')
+      if !has('patch-8.1.1799')
+        call s:unmap_menu_keys()
+      endif
+      let title = s:text[0]
+      let winid = popup_menu(s:text[1:], {
+            \ 'title': '  '.title.'  ',
+            \ 'callback': 'kite#onboarding#popup_callback',
+            \ })
+      call win_execute(winid, "normal! ".repeat('j', len(s:text[1:])-3))
+
+    else
+      let s:text[-3] = '1. '.s:text[-3]
+      let s:text[-2] = '2. '.s:text[-2]
+      let s:text[-1] = '3. '.s:text[-1]
+
+      call s:handle_choice(inputlist(s:text)-1)
+    endif
+  endif
+endfunction
+
+
+" Invoked when popup closes.
+function! kite#onboarding#popup_callback(_, result)
+  call s:handle_choice(2 - len(s:text[1:]) + a:result)
+endfunction
+
+
+function! s:handle_choice(index)
+  if a:index == 0  " learn now
+    call kite#utils#browse('https://kite.com')
+  elseif a:index == 2  " hide forever
+    call kite#utils#set_setting(s:option, 0)
+  endif
+endfunction
+
+
+" Removes any leading and trailing double quotation marks.
+function! s:trim(text, mask)
+  return substitute(substitute(a:text, '^'.a:mask, '', ''), a:mask.'$', '', '')
+endfunction
+
+
+function! s:unmap_menu_keys()
+  silent! nunmap <CR>
+  silent! nunmap <Space>
+  silent! nunmap j
+  silent! nunmap k
+  silent! nunmap x
+endfunction

--- a/autoload/kite/onboarding.vim
+++ b/autoload/kite/onboarding.vim
@@ -25,7 +25,7 @@ endfunction
 
 function! kite#onboarding#handler(response) abort
   if a:response.status == 200
-    silent execute 'tabedit' s:trim(a:response.body, '"')
+    silent execute 'tabedit' json_decode(a:response.body)
     call kite#utils#set_setting(s:option, 0)
 
   else
@@ -63,12 +63,6 @@ function! s:handle_choice(index)
   elseif a:index == 2  " hide forever
     call kite#utils#set_setting(s:option, 0)
   endif
-endfunction
-
-
-" Removes any leading and trailing double quotation marks.
-function! s:trim(text, mask)
-  return substitute(substitute(a:text, '^'.a:mask, '', ''), a:mask.'$', '', '')
 endfunction
 
 

--- a/autoload/kite/utils.vim
+++ b/autoload/kite/utils.vim
@@ -64,6 +64,17 @@ function! s:winshell()
   return kite#utils#windows() && &shellcmdflag !~# '^-'
 endfunction
 
+
+function! kite#utils#browse(url)
+  if kite#utils#windows()
+    let cmd = 'cmd /c start "" "'.a:url.'"'
+  else
+    let cmd = 'open "'.a:url.'"'
+  endif
+  silent call system(cmd)
+endfunction
+
+
 " From tpope/vim-fugitive
 function! s:shellescape(arg)
   if a:arg =~ '^[A-Za-z0-9_/.-]\+$'

--- a/plugin/kite.vim
+++ b/plugin/kite.vim
@@ -57,7 +57,7 @@ endif
 augroup Kite
   autocmd!
   autocmd BufEnter * call kite#bufenter()
-  autocmd VimEnter * ++nested call kite#onboarding#call()
+  autocmd VimEnter * ++nested if &filetype !~# '^git' | call kite#onboarding#call() | endif
 augroup END
 
 

--- a/plugin/kite.vim
+++ b/plugin/kite.vim
@@ -57,6 +57,7 @@ endif
 augroup Kite
   autocmd!
   autocmd BufEnter * call kite#bufenter()
+  autocmd VimEnter * ++nested call kite#onboarding#call()
 augroup END
 
 


### PR DESCRIPTION
Section 2.b.i. of the spec says "open the relevant help docs in the browser".  I didn't know what URL to use so for now the code uses kite.com.

As per the spec, the onboarding is triggered when Vim is next started.  However this could be for something unrelated like typing a commit message – when the user will not be interested in going through onboarding.

Perhaps the onboarding should be triggered when the next Python file is opened?