### PR TITLE
Activate for all Python file types

### DIFF
--- a/autoload/kite.vim
+++ b/autoload/kite.vim
@@ -176,6 +176,6 @@ endfunction
 
 
 function! s:supported_language()
-  return expand('%:e') == 'py'
+  return &filetype == 'python'
 endfunction
 

--- a/autoload/kite.vim
+++ b/autoload/kite.vim
@@ -176,6 +176,6 @@ endfunction
 
 
 function! s:supported_language()
-  return &filetype == 'python'
+  return &filetype == 'python' && expand('%:e') != 'pyi'
 endfunction
 

--- a/autoload/kite/client.vim
+++ b/autoload/kite/client.vim
@@ -279,11 +279,17 @@ let s:http_binary = kite#utils#lib('kite-http')
 
 if !empty($KITED_TEST_PORT)
   function! kite#client#request_history()
-    return json_decode(
+    let ret = json_decode(
           \   s:parse_response(
           \     s:internal_http('/testapi/request-history', 500)
           \   ).body
           \ )
+
+    if type(ret) != type([])
+      throw '/testapi/request-history did not return a list (type '.type(ret).')'
+    endif
+
+    return ret
   endfunction
 
   function! kite#client#reset_request_history()


### PR DESCRIPTION
Vim's filetype detection determines if a file is Python by:

- extension: `*.py,*.pyw,.pythonstartup,.pythonrc,*.ptl,*.pyi`
- shebang

See #219.