### PR TITLE
Improve completeopt handling

### DIFF
--- a/autoload/kite.vim
+++ b/autoload/kite.vim
@@ -41,6 +41,17 @@ function! kite#max_file_size()
 endfunction
 
 
+function! kite#configure_completeopt()
+  " If the user has configured completeopt, leave it alone.
+  redir => output
+    silent verbose set completeopt
+  redir END
+  if len(split(output, '\n')) > 1 | return | endif
+
+  set completeopt=menuone,noinsert
+endfunction
+
+
 function! s:setup_options()
   let s:pumheight = &pumheight
   if &pumheight == 0
@@ -54,10 +65,6 @@ function! s:setup_options()
 
   let s:shortmess = &shortmess
   set shortmess+=c
-
-  let s:completeopt = &completeopt
-  set completeopt+=menuone,noinsert
-  set completeopt-=longest,preview
 
   if kite#utils#windows()
     " Avoid taskbar flashing on Windows when executing system() calls.
@@ -73,7 +80,6 @@ function! s:restore_options()
   let &pumheight   = s:pumheight
   let &updatetime  = s:updatetime
   let &shortmess   = s:shortmess
-  let &completeopt = s:completeopt
   if kite#utils#windows()
     let &shelltemp = s:shelltemp
   endif

--- a/autoload/kite/completion.vim
+++ b/autoload/kite/completion.vim
@@ -39,6 +39,11 @@ endfunction
 
 " Manual invocation calls this method.
 function! kite#completion#complete(findstart, base)
+  let copts = split(&completeopt, ',')
+  if index(copts, 'longest')  != -1 | call kite#utils#warn("completeopt must not contain 'longest'") | return -3 | endif
+  if index(copts, 'menuone')  == -1 | call kite#utils#warn("completeopt must contain 'menuone'")     | return -3 | endif
+  if index(copts, 'noinsert') == -1 | call kite#utils#warn("completeopt must contain 'noinsert'")    | return -3 | endif
+
   if a:findstart
     " Store the buffer contents and cursor position here because when Vim
     " calls this function the second time (with a:findstart == 0) Vim has

--- a/autoload/kite/completion.vim
+++ b/autoload/kite/completion.vim
@@ -39,10 +39,10 @@ endfunction
 
 " Manual invocation calls this method.
 function! kite#completion#complete(findstart, base)
-  let copts = split(&completeopt, ',')
-  if index(copts, 'longest')  != -1 | call kite#utils#warn("completeopt must not contain 'longest'") | return -3 | endif
-  if index(copts, 'menuone')  == -1 | call kite#utils#warn("completeopt must contain 'menuone'")     | return -3 | endif
-  if index(copts, 'noinsert') == -1 | call kite#utils#warn("completeopt must contain 'noinsert'")    | return -3 | endif
+  if !s:completeopt_suitable()
+    let g:kite_auto_complete = 0
+    return -3
+  endif
 
   if a:findstart
     " Store the buffer contents and cursor position here because when Vim
@@ -255,3 +255,13 @@ function! s:before_function_call_argument(line)
   return a:line =~ '\v[(]([^)]+[=,])?\s*$'
 endfunction
 
+
+function! s:completeopt_suitable()
+  let copts = split(&completeopt, ',')
+
+  if index(copts, 'longest')  != -1 | call kite#utils#warn("completeopt must not contain 'longest'") | return 0 | endif
+  if index(copts, 'menuone')  == -1 | call kite#utils#warn("completeopt must contain 'menuone'")     | return 0 | endif
+  if index(copts, 'noinsert') == -1 | call kite#utils#warn("completeopt must contain 'noinsert'")    | return 0 | endif
+
+  return 1
+endfunction

--- a/plugin/kite.vim
+++ b/plugin/kite.vim
@@ -57,6 +57,7 @@ endif
 augroup Kite
   autocmd!
   autocmd BufEnter * call kite#bufenter()
+  autocmd VimEnter * call kite#configure_completeopt()
   autocmd VimEnter * nested if &filetype !~# '^git' | call kite#onboarding#call(0) | endif
 augroup END
 

--- a/test/editor_tests
+++ b/test/editor_tests
@@ -19,6 +19,7 @@ $VIM -u NONE -U NONE -i NONE -N \
   -c 'set updatetime=20'        \
   -c 'set nofixeol'             \
   -c 'set nomore'               \
+  -c 'doautocmd VimEnter'       \
   -S editor_json_tests_runner.vim
 
 esc=$(printf '\033')


### PR DESCRIPTION
If user has configured completeopt, leave it alone.  However if it
contains 'longest' or does not contain 'menuone' nor 'noinsert', warn
user on each completion attempt and abort the completion.

If user has not configured completeopt, set it to what works best for
Kite's completions: 'menuone,noinsert'.

See #217.