### PR TITLE
enable Go

### DIFF
--- a/autoload/kite.vim
+++ b/autoload/kite.vim
@@ -118,8 +118,12 @@ function s:setup_events()
     autocmd InsertCharPre            <buffer> call kite#completion#insertcharpre()
     autocmd TextChangedI             <buffer> call kite#completion#autocomplete()
 
-    autocmd CompleteDone             <buffer> call kite#completion#expand_newlines()
-    autocmd CompleteDone             <buffer> call kite#snippet#complete_done()
+    if &ft == 'go'
+      autocmd CompleteDone           <buffer> call kite#completion#expand_newlines()
+    endif
+    if &ft == 'python'
+      autocmd CompleteDone           <buffer> call kite#snippet#complete_done()
+    endif
 
     if exists('g:kite_documentation_continual') && g:kite_documentation_continual
       autocmd CursorHold,CursorHoldI <buffer> call kite#docs#docs()

--- a/autoload/kite.vim
+++ b/autoload/kite.vim
@@ -118,6 +118,7 @@ function s:setup_events()
     autocmd InsertCharPre            <buffer> call kite#completion#insertcharpre()
     autocmd TextChangedI             <buffer> call kite#completion#autocomplete()
 
+    autocmd CompleteDone             <buffer> call kite#completion#expand_newlines()
     autocmd CompleteDone             <buffer> call kite#snippet#complete_done()
 
     if exists('g:kite_documentation_continual') && g:kite_documentation_continual

--- a/autoload/kite.vim
+++ b/autoload/kite.vim
@@ -182,6 +182,6 @@ endfunction
 
 
 function! s:supported_language()
-  return expand('%:e') == 'py'
+  return index(['py', 'go'], expand('%:e')) >= 0
 endfunction
 

--- a/autoload/kite/completion.vim
+++ b/autoload/kite/completion.vim
@@ -4,6 +4,19 @@ let s:begin = 0
 let s:end = 0
 
 
+function! kite#completion#expand_newlines()
+  if empty(v:completed_item) | return | endif
+  if match(v:completed_item.word, '\n') == -1 | return | endif
+
+  let parts = split(getline('.'), '\n', 1)
+  delete _
+  call append(line('.')-1, parts)
+  -1
+  " startinsert! doesn't seem to work with: package main^@import ""^@
+  call feedkeys("\<Esc>A")
+endfunction
+
+
 function! kite#completion#insertcharpre()
   let s:should_trigger_completion = 1
 


### PR DESCRIPTION
send requests for `.go` files.

but this isn't quite enough because the experimental Go support in Kite may return newlines in the completion snippet text, which don't get inserted properly.