### PR TITLE
Use floating window for completeopt warning

### DIFF
--- a/autoload/kite/completion.vim
+++ b/autoload/kite/completion.vim
@@ -345,9 +345,9 @@ endfunction
 function! s:completeopt_suitable()
   let copts = split(&completeopt, ',')
 
-  if index(copts, 'longest')  != -1 | call s:popup_warn("completeopt must not contain 'longest'") | return 0 | endif
-  if index(copts, 'menuone')  == -1 | call s:popup_warn("completeopt must contain 'menuone'")     | return 0 | endif
-  if index(copts, 'noinsert') == -1 | call s:popup_warn("completeopt must contain 'noinsert'")    | return 0 | endif
+  if index(copts, 'longest')  != -1 | call s:popup_warn("Kite: completeopt must not contain 'longest'") | return 0 | endif
+  if index(copts, 'menuone')  == -1 | call s:popup_warn("Kite: completeopt must contain 'menuone'")     | return 0 | endif
+  if index(copts, 'noinsert') == -1 | call s:popup_warn("Kite: completeopt must contain 'noinsert'")    | return 0 | endif
 
   return 1
 endfunction

--- a/autoload/kite/completion.vim
+++ b/autoload/kite/completion.vim
@@ -345,9 +345,60 @@ endfunction
 function! s:completeopt_suitable()
   let copts = split(&completeopt, ',')
 
-  if index(copts, 'longest')  != -1 | call kite#utils#warn("completeopt must not contain 'longest'") | return 0 | endif
-  if index(copts, 'menuone')  == -1 | call kite#utils#warn("completeopt must contain 'menuone'")     | return 0 | endif
-  if index(copts, 'noinsert') == -1 | call kite#utils#warn("completeopt must contain 'noinsert'")    | return 0 | endif
+  if index(copts, 'longest')  != -1 | call s:popup_warn("completeopt must not contain 'longest'") | return 0 | endif
+  if index(copts, 'menuone')  == -1 | call s:popup_warn("completeopt must contain 'menuone'")     | return 0 | endif
+  if index(copts, 'noinsert') == -1 | call s:popup_warn("completeopt must contain 'noinsert'")    | return 0 | endif
 
   return 1
+endfunction
+
+
+function! s:popup_warn(msg)
+  if exists('*popup_notification')
+    call popup_notification(a:msg, {
+          \   'pos':   'botleft',
+          \   'line':  'cursor-1',
+          \   'col':   'cursor',
+          \   'moved': 'any',
+          \   'time':  2000
+          \ })
+  elseif exists('*nvim_open_win')
+    let lines = s:border(a:msg)
+    let buf = nvim_create_buf(v:false, v:true)
+    call nvim_buf_set_lines(buf, 0, -1, v:true, lines)
+    let winid = nvim_open_win(buf, v:false, {
+          \   'relative': 'cursor',
+          \   'anchor':   'SW',
+          \   'row':      0,
+          \   'col':      0,
+          \   'width':    strdisplaywidth(lines[0]),
+          \   'height':   len(lines),
+          \   'focusable': v:false,
+          \   'style':    'minimal'
+          \ })
+    call nvim_win_set_option(winid, 'winhighlight', 'Normal:WarningMsg')
+    call timer_start(2000, {-> execute("call nvim_win_close(".winid.", v:true)")})
+  else
+    call kite#utils#warn(a:msg)
+  endif
+endfunction
+
+
+" Converts:
+"
+"   A quick brown fox.
+"
+" Into:
+"
+"   +--------------------+
+"   | A quick brown fox. |
+"   +--------------------+
+"
+function! s:border(text)
+  return [
+        \ '+'.repeat('-', strdisplaywidth(a:text)+2).'+',
+        \ '| '.a:text.' |',
+        \ '+'.repeat('-', strdisplaywidth(a:text)+2).'+'
+        \ ]
+
 endfunction

--- a/autoload/kite/utils.vim
+++ b/autoload/kite/utils.vim
@@ -39,7 +39,7 @@ function! kite#utils#normalise_version(version)
     " Or use api_info().version.
     return lines[0]  " e.g. NVIM v0.2.2
   else
-    let [major, minor] = [v:version / 100, v:version % 100]
+    let [major, minor] = matchlist(lines[0], '\v(\d)\.(\d+)')[1:2]
 
     let patch_line = match(lines, ': \d')
     let patches = substitute(split(lines[patch_line], ': ')[1], ' ', '', 'g')

--- a/test/test_kite.vim
+++ b/test/test_kite.vim
@@ -267,7 +267,7 @@ function Test_normalise_version()
         \   'Included patches: 1-503, 505-680, 682-1283',
         \   'Compiled by root@apple.com',
         \ ], "\n")
-  call assert_equal('8.1.1-503,505-680,682-1283', kite#utils#normalise_version(version_str))
+  call assert_equal('8.0.1-503,505-680,682-1283', kite#utils#normalise_version(version_str))
 
   " macvim
   let version_str = join([


### PR DESCRIPTION
See #236.

To test this manually:

```
$ vim -c 'set cot="menu"' somefile.py
```

Then invoke an insert-mode completion with `<C-X><C-U>`, i.e. ctrl-x ctrl-u.