### PR TITLE
Respect replacement range in completions

### DIFF
--- a/autoload/kite.vim
+++ b/autoload/kite.vim
@@ -119,6 +119,8 @@ function s:setup_events()
     autocmd InsertCharPre            <buffer> call kite#completion#insertcharpre()
     autocmd TextChangedI             <buffer> call kite#completion#autocomplete()
 
+    autocmd CompleteDone             <buffer> call kite#completion#replace_range()
+
     if &ft == 'go'
       autocmd CompleteDone           <buffer> call kite#completion#expand_newlines()
     endif

--- a/autoload/kite/completion.vim
+++ b/autoload/kite/completion.vim
@@ -24,6 +24,7 @@ function! kite#completion#replace_range()
   if !empty(placeholders) | return | endif
 
   let col = col('.')
+  let _col = col
 
   " end of range
   let n = range.end - s:offset_before_completion
@@ -33,16 +34,19 @@ function! kite#completion#replace_range()
   endif
 
   " start of range
-  call kite#utils#goto_character(range.begin + 1)
-  let n = startcol - col('.')
+  let range_begin_col = col('.') - (kite#utils#character_offset() - range.begin)
+  let n = startcol - range_begin_col
   if n > 0
+    call kite#utils#goto_character(range.begin + 1)
     execute 'normal! "_'.n.'x'
     let col -= n
   endif
 
   " restore cursor position
-  execute 'normal!' (col+1).'|'
-  call feedkeys("\<Esc>la")
+  if col != _col
+    execute 'normal!' (col+1).'|'
+    call feedkeys("\<Esc>la")
+  endif
 endfunction
 
 

--- a/autoload/kite/completion.vim
+++ b/autoload/kite/completion.vim
@@ -29,6 +29,7 @@ function! kite#completion#replace_range()
   let n = range.end - s:offset_before_completion
   if n > 0
     execute 'normal! "_'.n.'x'
+    let col -= n
   endif
 
   " start of range
@@ -36,6 +37,7 @@ function! kite#completion#replace_range()
   let n = startcol - col('.')
   if n > 0
     execute 'normal! "_'.n.'x'
+    let col -= n
   endif
 
   " restore cursor position

--- a/autoload/kite/completion.vim
+++ b/autoload/kite/completion.vim
@@ -24,28 +24,23 @@ function! kite#completion#replace_range()
   if !empty(placeholders) | return | endif
 
   let col = col('.')
-  let _col = col
 
-  " end of range: delete from cursor postion to (range.end + len(v:completed_item.word)
-  let n = range.end + len(v:completed_item.word) - kite#utils#character_offset()
+  " end of range
+  let n = range.end - s:offset_before_completion
   if n > 0
     execute 'normal! "_'.n.'x'
-    let col -= n
   endif
 
-  " start of range: delete from replace.begin to startcol
+  " start of range
   call kite#utils#goto_character(range.begin + 1)
   let n = startcol - col('.')
   if n > 0
     execute 'normal! "_'.n.'x'
-    let col -= n
   endif
 
   " restore cursor position
-  if _col != col
-    execute 'normal!' (col+1).'|'
-    call feedkeys("\<Esc>la")
-  endif
+  execute 'normal!' (col+1).'|'
+  call feedkeys("\<Esc>la")
 endfunction
 
 
@@ -264,6 +259,7 @@ function! kite#completion#handler(counter, startcol, response) abort
 
   if mode(1) ==# 'i'
     let s:startcol = a:startcol+1
+    let s:offset_before_completion = kite#utils#character_offset()
     call complete(a:startcol+1, matches)
   endif
 endfunction

--- a/autoload/kite/snippet.vim
+++ b/autoload/kite/snippet.vim
@@ -38,9 +38,9 @@ function! kite#snippet#complete_done()
   call s:setup_stack()
 
   if has_key(v:completed_item, 'user_data') && !empty(v:completed_item.user_data)
-    let placeholders = json_decode(v:completed_item.user_data)
+    let placeholders = json_decode(v:completed_item.user_data).placeholders
   elseif exists('b:kite_completions') && has_key(b:kite_completions, v:completed_item.word)
-    let placeholders = json_decode(b:kite_completions[v:completed_item.word])
+    let placeholders = json_decode(b:kite_completions[v:completed_item.word]).placeholders
     let b:kite_completions = {}
   else
     return


### PR DESCRIPTION
This implementation differs from the original by checking for a successful completion at the top of the `replace_range()` function.

This should fix case 2 in https://github.com/kiteco/kiteco/issues/9748.

See #242.