### PR TITLE
Skip completions etc when Kite not running

### DIFF
--- a/autoload/kite/events.vim
+++ b/autoload/kite/events.vim
@@ -41,6 +41,6 @@ endfunction
 function! kite#events#handler(bufnr, response)
   let s:events_pending -= 1
 
-  call setbufvar(a:bufnr, 'kite_skip', a:response.status == 403)
+  call setbufvar(a:bufnr, 'kite_skip', (a:response.status == 0 || a:response.status == 403))
 endfunction
 


### PR DESCRIPTION
This prevents the plugin from sending any completion or hover requests when an event request shows that Kite itself is not running.

In theory sending these requests should not cause any problems, but just maybe it's related to the weird-characters problem.

With this patch the plugin will continue to send events and if Kite is activated it will notice and resume completions etc.