### PR TITLE
Switch on javascript support

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,18 +45,18 @@ Once installed, the plugin will be automatically updated by Kite when necessary.
 
 ### Configuring supported languages
 
-Kite supports Python & JavaScript (on by default) and Golang (off by default and in beta).
+Kite supports Python (on by default), JavaScript (off by default), and Golang (off by default and in beta).
 
-To turn off Python or JavaScript support, set the `g:kite_supported_languages` list in your vimrc:
+To turn off Python, set the `g:kite_supported_languages` list in your vimrc:
 
 ```viml
 let g:kite_supported_languages = []
 ```
 
-To turn on Golang support, ensure the Kite Engine has Golang enabled and then set the `g:kite_supported_languages` list in your vimrc:
+To turn on JavaScript or Golang support, ensure the Kite Engine has JavaScript or Golang enabled and then set the `g:kite_supported_languages` list in your vimrc:
 
 ```viml
-let g:kite_supported_languages = ['python', 'go']
+let g:kite_supported_languages = ['python', 'javascript', 'go']
 ```
 
 [Learn more about why Kite is the best autocomplete for Vim.](https://kite.com/integrations/vim/)

--- a/autoload/kite/languages.vim
+++ b/autoload/kite/languages.vim
@@ -10,6 +10,10 @@ function! kite#languages#supported_by_plugin()
     return 1
   endif
 
+  if &filetype == 'javascript' && index(g:kite_supported_languages, 'javascript') != -1
+    return 1
+  endif
+
   return 0
 endfunction
 

--- a/plugin/kite.vim
+++ b/plugin/kite.vim
@@ -22,7 +22,7 @@ filetype on
 
 
 if !exists('g:kite_supported_languages')
-  let g:kite_supported_languages = ['python']
+  let g:kite_supported_languages = ['python', 'javascript']
 endif
 
 if !exists('g:kite_auto_complete')

--- a/plugin/kite.vim
+++ b/plugin/kite.vim
@@ -22,7 +22,7 @@ filetype on
 
 
 if !exists('g:kite_supported_languages')
-  let g:kite_supported_languages = ['python', 'javascript']
+  let g:kite_supported_languages = ['python']
 endif
 
 if !exists('g:kite_auto_complete')


### PR DESCRIPTION
This PR activates the plugin for javascript files.

I wasn't sure what to do about signature completions: the [code](https://github.com/kiteco/vim-plugin/blob/ffb3500a5b018e6469385ec4b9080b392518f210/autoload/kite/signature.vim) digs out values from nested keys with `python` in the name (just search for "python" on that page).

