### PR TITLE
Get max file size from kited

### DIFF
--- a/autoload/kite.vim
+++ b/autoload/kite.vim
@@ -38,7 +38,8 @@ endfunction
 
 
 function! kite#max_file_size()
-  return 76800  " 75KB
+  " Fallback to 1MB
+  return get(b:, 'kite_max_file_size', 1048576)
 endfunction
 
 
@@ -107,6 +108,7 @@ function! kite#bufenter()
       call s:setup_options()
       call s:setup_events()
       call s:setup_mappings()
+      call s:set_max_file_size()
 
       setlocal completefunc=kite#completion#complete
 
@@ -180,6 +182,14 @@ function! s:setup_mappings()
 
   if empty(maparg('<C-]>', 'n'))
     nmap <silent> <buffer> <C-]> :KiteGotoDefinition<CR>
+  endif
+endfunction
+
+
+function! s:set_max_file_size()
+  let max_file_size = kite#client#max_file_size()
+  if max_file_size != -1
+    let b:kite_max_file_size = max_file_size
   endif
 endfunction
 

--- a/autoload/kite/client.vim
+++ b/autoload/kite/client.vim
@@ -11,6 +11,7 @@ let s:copilot_path       = 'kite://home'
 let s:counter_path       = '/clientapi/metrics/counters'
 let s:settings_path      = 'kite://settings'
 let s:permissions_path   = 'kite://settings/permissions'
+let s:max_file_size_path = '/clientapi/settings/max_file_size_kb'
 
 
 function! kite#client#docs(word)
@@ -74,6 +75,23 @@ function! kite#client#languages(handler)
     let response = s:external_http(s:base_url.path, g:kite_short_timeout)
   endif
   return a:handler(s:parse_response(response))
+endfunction
+
+
+" Returns max file size in bytes, or -1 if not available.
+function! kite#client#max_file_size()
+  let path = s:max_file_size_path
+  if has('channel')
+    let response = s:internal_http(path, g:kite_short_timeout)
+  else
+    let response = s:external_http(s:base_url.path, g:kite_short_timeout)
+  endif
+  let result = s:parse_response(response)
+  if result.status == 200
+    return result.body / 1024
+  else
+    return -1
+  endif
 endfunction
 
 

--- a/autoload/kite/client.vim
+++ b/autoload/kite/client.vim
@@ -88,7 +88,7 @@ function! kite#client#max_file_size()
   endif
   let result = s:parse_response(response)
   if result.status == 200
-    return result.body / 1024
+    return result.body * 1024
   else
     return -1
   endif


### PR DESCRIPTION
See https://github.com/kiteco/kiteco/issues/11826.

Since my Kite doesn't have the `/clientapi/settings/max_file_size_kb` endpoint yet, I assumed the endpoint's response would consist solely of the number.

The plugin queries the endpoint synchronously on `BufEnter`.  If the endpoint doesn't respond in time, or responds with a non-200 status code, the plugin falls back to a 1MB max file size.