### PR TITLE
Support for all-language lexical

### DIFF
--- a/autoload/kite/languages.vim
+++ b/autoload/kite/languages.vim
@@ -6,7 +6,7 @@ function! kite#languages#supported_by_plugin()
     return 1
   endif
 
-  for lang in ['go', 'javascript']
+  for lang in ['go', 'javascript', 'vue', 'typescript', 'css', 'html', 'less', 'c', 'scala', 'java', 'kotlin']
     if s:supported_filetype(lang)
       return 1
     endif

--- a/autoload/kite/languages.vim
+++ b/autoload/kite/languages.vim
@@ -2,17 +2,15 @@ let s:languages_supported_by_kited = []
 
 " Returns true if the current buffer's language is supported by this plugin, false otherwise.
 function! kite#languages#supported_by_plugin()
-  if &filetype == 'python' && expand('%:e') != 'pyi' && index(g:kite_supported_languages, 'python') != -1
+  if s:supported_filetype('python') && expand('%:e') != 'pyi'
     return 1
   endif
 
-  if &filetype == 'go' && index(g:kite_supported_languages, 'go') != -1
-    return 1
-  endif
-
-  if &filetype == 'javascript' && index(g:kite_supported_languages, 'javascript') != -1
-    return 1
-  endif
+  for lang in ['go', 'javascript']
+    if s:supported_filetype(lang)
+      return 1
+    endif
+  endfor
 
   return 0
 endfunction
@@ -33,4 +31,9 @@ function! kite#languages#handler(response)
   if a:response.status != 200 | return [] | endif
 
   return json_decode(a:response.body)
+endfunction
+
+
+function s:supported_filetype(name)
+  return &filetype == a:name && index(g:kite_supported_languages, a:name) != -1
 endfunction


### PR DESCRIPTION
See https://github.com/kiteco/kiteco/issues/11793.

This PR expands the list of languages for which the plugin can activate.

The languages for which the plugin activates by default remain the same: only python.  However the user can change this by setting the `g:kite_supported_languages` variable in their vimrc, as documented already.

I wasn't able to test this as kited doesn't seem to support these extra languages yet.