### PR TITLE
Use status suffix from json.short

### DIFF
--- a/autoload/kite/status.vim
+++ b/autoload/kite/status.vim
@@ -42,20 +42,11 @@ function! kite#status#handler(buffer, response)
 
   let json = json_decode(a:response.body)
 
-  " indexing | ready | noIndex
-  let status = json.status
   let msg = ''
 
-  if status == 'ready'
-    let msg = 'Kite'
-  endif
-
-  if status == 'indexing'
-    let msg = 'Kite: indexing'
-  endif
-
-  if status == 'noIndex'
-    let msg = 'Kite: ready (unindexed)'
+  let suffix = get(json, 'short', 'FIELD MISSING')
+  if suffix !=# 'FIELD MISSING'
+    let msg = join(['Kite: ', suffix], '')
   endif
 
   if msg !=# getbufvar(a:buffer, 'kite_status')


### PR DESCRIPTION
Addresses https://github.com/kiteco/kiteco/issues/11798 for vim

### What was done
We removed model warmup and added a new status for when models are warming up. I considered adding a simple
```
if status == 'initializing'
  let msg = 'Kite: initializing'
endif
```
but this seemed a little more flexible from a future changes standpoint (text is also harder to synchronize between editors if each editor switches off the status response). The endpoint has been returning `{ status, short, long }`, where `short` is `ready | indexing | initializing | ready (no index) | unsupported | disabled`, for long while now, so I don't think this would break anything for users not on the most recent version of Kite.

Kind of a separate question: does `kite#statusline()` integrate with lightline on neovim? Wanted to manually test this, but had some trouble with that, so I ended up just doing some string checking instead.