### PR TITLE
Remove obsolete maps for <c-e>, <c-y>, <cr>

### DIFF
--- a/autoload/kite.vim
+++ b/autoload/kite.vim
@@ -154,24 +154,6 @@ endfunction
 
 
 function! s:setup_mappings()
-  " When the pop-up menu is closed with <C-e>, <C-y>, or <CR>,
-  " the TextChangedI event is fired again, which re-opens the
-  " pop-up menu.  To avoid this, we set a flag when one of those
-  " keys is pressed.
-  "
-  " Note the <CR> mapping can conflict with vim-endwise because vim-endwise
-  " also maps <CR>.  To work around the conflict:
-  "
-  "     let g:kite_deconflict_cr = 1
-  "
-  imap <buffer> <expr> <C-e> kite#completion#popup_exit("\<C-e>")
-  imap <buffer> <expr> <C-y> kite#completion#popup_exit("\<C-y>")
-  if exists('g:kite_deconflict_cr') && g:kite_deconflict_cr
-    imap <silent> <buffer> <CR> <C-R>=kite#completion#popup_exit('')<CR><CR>
-  else
-    imap <buffer> <expr> <CR> kite#completion#popup_exit("\<CR>")
-  endif
-
   if exists('g:kite_tab_complete')
     imap <buffer> <expr> <Tab> pumvisible() ? "\<C-y>" : "\<Tab>"
   endif

--- a/autoload/kite/completion.vim
+++ b/autoload/kite/completion.vim
@@ -76,14 +76,6 @@ function! kite#completion#insertcharpre()
 endfunction
 
 
-function! kite#completion#popup_exit(key)
-  if pumvisible()
-    let s:should_trigger_completion = 0
-  endif
-  return a:key
-endfunction
-
-
 function! kite#completion#autocomplete()
   if !g:kite_auto_complete | return | endif
   if exists('b:kite_skip') && b:kite_skip | return | endif


### PR DESCRIPTION
These maps were intended to stop the insert-mode completion menu
immediately re-opening just after it was closed with `<c-e>`, `<c-y>`, or
`<cr>`.  However they are not necessary because:

- when completion is triggered the s:should_trigger_completion flag is
  cleared;
- InsertCharPre is only fired for visible characters;
- therefore closing the completion menu with one of these keys will not
  cause the menu to reopen.

Related reading:

- Vim 8.0.1494: no autocmd triggered in Insert mode with visible popup
  menu.
  https://github.com/vim/vim/commit/5a093437199001a0d60d8e18e2b9539b99a7757c
- lifepillar/vim-mucomplete#66: remapping <c-e>, <c-y>, <cr> does not seem to be
  necessary
  https://github.com/lifepillar/vim-mucomplete/issues/66
- lifepillar/vim-mucomplete@58b9146233: restore backward compatibility
  with Vim < 8.0.0283.
  https://github.com/lifepillar/vim-mucomplete/commit/58b9146233fed3b71382c48089c821e7ed891e3e

See #313, #315.