### PR TITLE
Support .pyw Python extension.

### DIFF
--- a/autoload/kite/languages.vim
+++ b/autoload/kite/languages.vim
@@ -21,6 +21,7 @@ function! kite#languages#supported_by_plugin()
         \ 'm',
         \ 'php',
         \ 'py',
+        \ 'pyw',
         \ 'rb',
         \ 'scala',
         \ 'sh',


### PR DESCRIPTION
Adds support for the .pyw Python extension. Required for kiteco/kiteco#12167

@airblade I'm not sure if this change is necessary since I'm already receiving completions for `.pyw` files, but I've added `.pyw` to the supported extensions in case.