### PR TITLE
Do not map keys we feed in

### DIFF
--- a/autoload/kite/completion.vim
+++ b/autoload/kite/completion.vim
@@ -400,7 +400,7 @@ endfunction
 " combo being applied in normal mode).  To avoid this we use the 'i' flag
 " which ensures the keys are processed immediately.
 function s:feedkeys(keys)
-  call feedkeys(a:keys, 'i')
+  call feedkeys(a:keys, 'in')
 endfunction
 
 


### PR DESCRIPTION
This is like using `normal!` instead of `normal`.  We want to invoke
plain vim functionality, not any custom behaviour users may have defined
through mappings.

Closes #348.