### PR TITLE
Fix issue with Neovim preview mode

### DIFF
--- a/autoload/kite.vim
+++ b/autoload/kite.vim
@@ -48,7 +48,9 @@ function! kite#configure_completeopt()
   redir => output
     silent verbose set completeopt
   redir END
-  if len(split(output, '\n')) > 1 | return | endif
+  if len(split(output, '\n')) > 1
+    return
+  endif
 
   set completeopt=menuone,noinsert
 endfunction
@@ -77,7 +79,9 @@ endfunction
 
 
 function! s:restore_options()
-  if !exists('s:pumheight') | return | endif
+  if !exists('s:pumheight')
+    return
+  endif
 
   let &pumheight   = s:pumheight
   unlet s:pumheight

--- a/autoload/kite/async.vim
+++ b/autoload/kite/async.vim
@@ -28,7 +28,9 @@ function! kite#async#sync(cmd)
 
   let vim = !has('nvim')
   while type(s:async_sync_outputs[async_sync_id]) == job_type
-    if vim | call job_status(job_handle) | endif
+    if vim
+      call job_status(job_handle)
+    endif
     sleep 5m
   endwhile
 

--- a/autoload/kite/codenav.vim
+++ b/autoload/kite/codenav.vim
@@ -20,7 +20,9 @@ endfunction
 
 
 function! kite#codenav#handler(response) abort
-  if a:response.status == 200 | return | endif
+  if a:response.status == 200
+    return
+  endif
 
   if a:response.status == 0
     call kite#utils#warn("Kite could not be reached. Please check that Kite Engine is running.")

--- a/autoload/kite/completion.vim
+++ b/autoload/kite/completion.vim
@@ -5,8 +5,12 @@ let s:end = 0
 
 
 function! kite#completion#replace_range()
-  if empty(v:completed_item) | return | endif
-  if !exists('s:startcol') | return | endif
+  if empty(v:completed_item)
+    return
+  endif
+  if !exists('s:startcol')
+    return
+  endif
   let startcol = s:startcol
   unlet s:startcol
 
@@ -21,7 +25,9 @@ function! kite#completion#replace_range()
   endif
 
   " The range seems to be wrong when placeholders are involved so stop here.
-  if !empty(placeholders) | return | endif
+  if !empty(placeholders)
+    return
+  endif
 
   let col = col('.')
   let _col = col
@@ -51,8 +57,12 @@ endfunction
 
 
 function! kite#completion#expand_newlines()
-  if empty(v:completed_item) | return | endif
-  if match(v:completed_item.word, '\n') == -1 | return | endif
+  if empty(v:completed_item)
+    return
+  endif
+  if match(v:completed_item.word, '\n') == -1
+    return
+  endif
 
   let parts = split(getline('.'), '\n', 1)
   delete _
@@ -77,9 +87,15 @@ endfunction
 
 
 function! kite#completion#autocomplete()
-  if !g:kite_auto_complete | return | endif
-  if exists('b:kite_skip') && b:kite_skip | return | endif
-  if wordcount().bytes > kite#max_file_size() | return | endif
+  if !g:kite_auto_complete
+    return
+  endif
+  if exists('b:kite_skip') && b:kite_skip
+    return
+  endif
+  if wordcount().bytes > kite#max_file_size()
+    return
+  endif
 
   if s:should_trigger_completion
     let s:should_trigger_completion = 0

--- a/autoload/kite/docs.vim
+++ b/autoload/kite/docs.vim
@@ -4,7 +4,9 @@ function! kite#docs#docs()
     return
   endif
 
-  if empty(expand('<cword>')) | return | endif
+  if empty(expand('<cword>'))
+    return
+  endif
 
   let b:kite_id = ''
 

--- a/autoload/kite/hover.vim
+++ b/autoload/kite/hover.vim
@@ -1,6 +1,10 @@
 function! kite#hover#hover()
-  if exists('b:kite_skip') && b:kite_skip | return | endif
-  if wordcount().bytes > kite#max_file_size() | return | endif
+  if exists('b:kite_skip') && b:kite_skip
+    return
+  endif
+  if wordcount().bytes > kite#max_file_size()
+    return
+  endif
 
   let filename = kite#utils#filepath(1)
   let hash = kite#utils#buffer_md5()
@@ -16,8 +20,12 @@ function! kite#hover#goto_definition()
     return
   endif
 
-  if exists('b:kite_skip') && b:kite_skip | return | endif
-  if wordcount().bytes > kite#max_file_size() | return | endif
+  if exists('b:kite_skip') && b:kite_skip
+    return
+  endif
+  if wordcount().bytes > kite#max_file_size()
+    return
+  endif
 
   let filename = kite#utils#filepath(1)
   let hash = kite#utils#buffer_md5()

--- a/autoload/kite/languages.vim
+++ b/autoload/kite/languages.vim
@@ -59,7 +59,9 @@ endfunction
 
 
 function! kite#languages#handler(response)
-  if a:response.status != 200 | return [] | endif
+  if a:response.status != 200
+    return []
+  endif
 
   return json_decode(a:response.body)
 endfunction

--- a/autoload/kite/snippet.vim
+++ b/autoload/kite/snippet.vim
@@ -1,5 +1,7 @@
 function! s:setup_stack()
-  if exists('b:kite_stack') | return | endif
+  if exists('b:kite_stack')
+    return
+  endif
 
   " stack:
   "  [
@@ -34,7 +36,9 @@ endfunction
 
 
 function! kite#snippet#complete_done()
-  if empty(v:completed_item) | return | endif
+  if empty(v:completed_item)
+    return
+  endif
   call s:setup_stack()
 
   if has_key(v:completed_item, 'user_data') && !empty(v:completed_item.user_data)
@@ -196,7 +200,9 @@ endfunction
 " Adjust current and subsequent placeholders for the amount of text entered
 " at the placeholder we are leaving.
 function! s:update_placeholder_locations()
-  if !exists('b:kite_line_length') | return | endif
+  if !exists('b:kite_line_length')
+    return
+  endif
 
   let line_length_delta = col('$') - b:kite_line_length
 
@@ -226,7 +232,9 @@ endfunction
 
 function! s:highlight_current_level_placeholders()
   let group = s:highlight_group_for_placeholders()
-  if empty(group) | return | endif
+  if empty(group)
+    return
+  endif
 
   let linenr = line('.')
   for ph in b:kite_stack.peek().placeholders
@@ -282,7 +290,9 @@ function! s:remove_smaps_for_printable_characters()
     let mappings = split(maps, "\n")
 
     " 'No mapping found' or localised equivalent (starts with capital letter).
-    if len(mappings) == 1 && mappings[0][0] =~ '\u' | continue | endif
+    if len(mappings) == 1 && mappings[0][0] =~ '\u'
+      continue
+    endif
 
     " Assume select-mode maps are deliberate and ignore them.
     call filter(mappings, 'v:val[0:2] !~# "s"')
@@ -293,7 +303,9 @@ function! s:remove_smaps_for_printable_characters()
       "                               mode lhs
 
       " Ignore keycodes for non-printable characters, e.g. <Left>
-      if lhs[0] == '<' && index(printable_keycodes, lhs) == -1 | continue | endif
+      if lhs[0] == '<' && index(printable_keycodes, lhs) == -1
+        continue
+      endif
 
       " Remember the mapping so we can restore it later.
       call add(b:kite_maps, maparg(lhs, 's', 0, 1))
@@ -379,8 +391,12 @@ endfunction
 
 
 function! s:cursormoved()
-  if !exists('b:kite_linenr') | return | endif
-  if b:kite_linenr == line('.') | return | endif
+  if !exists('b:kite_linenr')
+    return
+  endif
+  if b:kite_linenr == line('.')
+    return
+  endif
 
   " TODO check whether the cursor is outside the bounds of the completion?
 

--- a/autoload/kite/status.vim
+++ b/autoload/kite/status.vim
@@ -2,7 +2,9 @@
 "
 " Optional argument is a timer id (when called by a timer).
 function! kite#status#status(...)
-  if !s:status_in_status_line() | return | endif
+  if !s:status_in_status_line()
+    return
+  endif
 
   let buf = bufnr('')
   let msg = 'NOT SET'
@@ -38,7 +40,9 @@ endfunction
 
 function! kite#status#handler(buffer, response)
   call kite#utils#log('kite status status: '.a:response.status.', body: '.a:response.body)
-  if a:response.status != 200 | return | endif
+  if a:response.status != 200
+    return
+  endif
 
   let json = json_decode(a:response.body)
 


### PR DESCRIPTION
Fixes kiteco/issue-tracker#719

Mitigates an outstanding bug with Neovim (neovim/neovim#8796) where one-line if statements cause errors in preview mode (`:set inccommand=split` or `:set inccommand=nosplit`)